### PR TITLE
Document repository access issue for review

### DIFF
--- a/docs/yoshihara_project_review.md
+++ b/docs/yoshihara_project_review.md
@@ -1,0 +1,11 @@
+# Review Request: yoshihara-project
+
+## Repository Access Issue
+- Attempted to clone `https://github.com/hiroto107/yoshihara-project.git` from the review environment.
+- Cloning failed because outbound HTTPS tunneling is blocked, resulting in `fatal: unable to access ... CONNECT tunnel failed, response 403`.
+
+## Suggested Next Steps
+- Provide a repository archive (e.g., `.zip` or `.tar.gz`) within the task workspace, or
+- Mirror the repository into this workspace via a local path so that an offline review can be performed.
+
+Once the source code is accessible inside the workspace, a full review can proceed.


### PR DESCRIPTION
## Summary
- document the failure to clone hiroto107/yoshihara-project from the review environment
- outline next steps for providing repository access so the review can proceed

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f9f5c5ed4c832cad96a5c4b4e33136