### PR TITLE
fix: delegate_capsule実装 + Phase3 capsule_tx_id修正 (#70)

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "formix"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 zeroize = { version = "1.8", features = ["derive"] }

--- a/client/src/adapter/external/ao/data_item.rs
+++ b/client/src/adapter/external/ao/data_item.rs
@@ -2,8 +2,8 @@
 
 use std::fmt;
 
-use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use rand::rngs::OsRng;
 use rsa::pss::SigningKey;
 use rsa::signature::RandomizedSigner;

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -60,7 +60,7 @@ impl AsRef<[u8]> for Binary {
 }
 
 mod base64_serde {
-    use base64::{Engine, engine::general_purpose::STANDARD};
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>

--- a/client/src/adapter/external/ao/mod.rs
+++ b/client/src/adapter/external/ao/mod.rs
@@ -26,7 +26,7 @@ pub use data_item::{ArweaveJWK, DataItemBuilder, DataItemSigner};
 pub use message::{
     AOAttribute, AOEvent, AOMessageTags, AOResponse, Binary, BlobMeta, CFragEntry, CapsuleInfo,
     CapsuleStatus, ExecuteMsg, GetCFragResponse, GetCFragsBySecretResponse,
-    ListCapsulesByKFragResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH, QueryMsg, ValidateMessage,
+    ListCapsulesByKFragResponse, QueryMsg, ValidateMessage, MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };
 #[cfg(feature = "production-ao")]
 pub use production_client::ProductionAOClient;

--- a/client/src/adapter/external/ao/production_client.rs
+++ b/client/src/adapter/external/ao/production_client.rs
@@ -166,8 +166,8 @@ impl ProductionAOClient {
                 .filter(|s| !s.is_empty())
             {
                 use base64::{
-                    Engine,
                     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+                    Engine,
                 };
                 Some(
                     match STANDARD
@@ -219,8 +219,8 @@ impl ProductionAOClient {
             // Standard AO CU: Output.data is a base64-encoded string
             if let Some(data_str) = obj.get("data").and_then(|d| d.as_str()) {
                 use base64::{
-                    Engine,
                     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+                    Engine,
                 };
                 return match STANDARD
                     .decode(data_str)

--- a/client/src/adapter/external/arweave/client.rs
+++ b/client/src/adapter/external/arweave/client.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use super::config::ArweaveClientConfig;
 use super::merkle::compute_data_root;
-use super::transaction::{ArweaveTransaction, EncodedTag, build_signature_data};
+use super::transaction::{build_signature_data, ArweaveTransaction, EncodedTag};
 
 // =============================================================================
 // GraphQL Response Types
@@ -78,13 +78,13 @@ pub(crate) struct GraphQLError {
 
 /// Encode bytes to Base64URL format (no padding)
 pub fn base64url_encode(bytes: &[u8]) -> String {
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
 /// Decode Base64URL format to bytes
 pub fn base64url_decode(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     URL_SAFE_NO_PAD.decode(encoded)
 }
 

--- a/client/src/adapter/external/arweave/wallet.rs
+++ b/client/src/adapter/external/arweave/wallet.rs
@@ -187,6 +187,6 @@ fn decode_jwk_field(
 }
 
 fn base64url_decode_internal(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     URL_SAFE_NO_PAD.decode(encoded)
 }

--- a/client/src/adapter/external/mod.rs
+++ b/client/src/adapter/external/mod.rs
@@ -12,7 +12,7 @@ pub use arweave::{ArweaveClientConfig, ArweaveClientImpl, ArweaveWallet};
 pub use ao::{
     AOAttribute, AOClient, AOConfig, AOEvent, AOMessageTags, AOResponse, Binary, BlobMeta,
     CapsuleInfo, CapsuleStatus, ExecuteMsg, GetCFragResponse, ListCapsulesByKFragResponse,
-    MAX_BINARY_SIZE, MAX_ID_LENGTH, QueryMsg, ValidateMessage,
+    QueryMsg, ValidateMessage, MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };
 #[cfg(feature = "production-ao")]
 pub use ao::{ArweaveJWK, DataItemBuilder, DataItemSigner, ProductionAOClient};

--- a/client/src/adapter/repository_impl/capsule_impl.rs
+++ b/client/src/adapter/repository_impl/capsule_impl.rs
@@ -16,7 +16,7 @@ use crate::domain::errors::DomainResult;
 use crate::domain::value_objects::{CapsuleId, SecretId};
 use crate::repositories::{CapsuleRepository, Repository};
 
-use super::{ArweaveClient, Tag, tag_helpers, tag_names, tag_values};
+use super::{tag_helpers, tag_names, tag_values, ArweaveClient, Tag};
 
 /// Serializable representation of Capsule for Arweave storage
 #[derive(Serialize, Deserialize)]

--- a/client/src/adapter/repository_impl/cfrag_impl.rs
+++ b/client/src/adapter/repository_impl/cfrag_impl.rs
@@ -18,7 +18,7 @@ use crate::domain::errors::DomainResult;
 use crate::domain::value_objects::{CFragId, KFragId, SecretId};
 use crate::repositories::{CFragRepository, Repository};
 
-use super::{ArweaveClient, Tag, tag_helpers, tag_names, tag_values};
+use super::{tag_helpers, tag_names, tag_values, ArweaveClient, Tag};
 
 /// Serializable representation of CFrag for Arweave storage
 #[derive(Serialize, Deserialize)]

--- a/client/src/adapter/repository_impl/kfrag_impl.rs
+++ b/client/src/adapter/repository_impl/kfrag_impl.rs
@@ -18,7 +18,7 @@ use crate::domain::errors::DomainResult;
 use crate::domain::value_objects::{KFragId, SecretId};
 use crate::repositories::{KFragRepository, Repository};
 
-use super::{ArweaveClient, Tag, tag_helpers, tag_names, tag_values};
+use super::{tag_helpers, tag_names, tag_values, ArweaveClient, Tag};
 
 /// Serializable representation of KFrag for Arweave storage
 #[derive(Serialize, Deserialize)]

--- a/client/src/adapter/repository_impl/mod.rs
+++ b/client/src/adapter/repository_impl/mod.rs
@@ -132,7 +132,7 @@ pub trait ArweaveClient {
 
 /// Helper functions for creating common tags
 pub mod tag_helpers {
-    use super::{Tag, tag_names, tag_values};
+    use super::{tag_names, tag_values, Tag};
 
     /// Create application name tag
     pub fn app_tag() -> Tag {

--- a/client/src/adapter/repository_impl/secret_impl.rs
+++ b/client/src/adapter/repository_impl/secret_impl.rs
@@ -16,7 +16,7 @@ use crate::domain::errors::DomainResult;
 use crate::domain::value_objects::{CapsuleId, KFragId, SecretId, ShareCollectionId};
 use crate::repositories::{Repository, SecretRepository};
 
-use super::{ArweaveClient, Tag, tag_helpers, tag_values};
+use super::{tag_helpers, tag_values, ArweaveClient, Tag};
 
 /// Serializable representation of Secret for Arweave storage
 #[derive(Serialize, Deserialize)]

--- a/client/src/adapter/repository_impl/share_impl.rs
+++ b/client/src/adapter/repository_impl/share_impl.rs
@@ -16,7 +16,7 @@ use crate::domain::errors::DomainResult;
 use crate::domain::value_objects::{SecretId, ShareCollectionId};
 use crate::repositories::{Repository, ShareCollectionRepository};
 
-use super::{ArweaveClient, Tag, tag_helpers, tag_names, tag_values};
+use super::{tag_helpers, tag_names, tag_values, ArweaveClient, Tag};
 
 /// Serializable representation of EncryptedShareData
 #[derive(Serialize, Deserialize)]

--- a/client/src/controller/mod.rs
+++ b/client/src/controller/mod.rs
@@ -9,6 +9,6 @@ pub mod extractor;
 pub mod validator;
 
 pub use di::ControllerContainer;
-pub use error::{MAX_SHARES, MIN_THRESHOLD, ValidationError, error_codes};
+pub use error::{error_codes, ValidationError, MAX_SHARES, MIN_THRESHOLD};
 pub use extractor::{RecoverExtractor, ShareExtractor};
 pub use validator::{RecoverValidator, ShareValidator};

--- a/client/src/controller/validator.rs
+++ b/client/src/controller/validator.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use subtle::ConstantTimeEq;
 
-use crate::controller::error::{MAX_SHARES, MIN_THRESHOLD, ValidationError, error_codes};
+use crate::controller::error::{error_codes, ValidationError, MAX_SHARES, MIN_THRESHOLD};
 use crate::usecase::core::crypto::{CryptoService, PublicKey, SecretKey};
 
 /// Validator for secret sharing requests

--- a/client/src/domain/mod.rs
+++ b/client/src/domain/mod.rs
@@ -15,8 +15,8 @@ pub use entities::{
 
 // Re-export value objects
 pub use value_objects::{
-    CFragId, CapsuleId, KFragId, KeyPair, SYMMETRIC_KEY_SIZE, SecretData, SecretId,
-    ShareCollectionId, SymmetricKey,
+    CFragId, CapsuleId, KFragId, KeyPair, SecretData, SecretId, ShareCollectionId, SymmetricKey,
+    SYMMETRIC_KEY_SIZE,
 };
 
 pub use errors::{DomainError, DomainResult};

--- a/client/src/domain/value_objects/mod.rs
+++ b/client/src/domain/value_objects/mod.rs
@@ -11,4 +11,4 @@ mod symmetric_key;
 pub use ids::{CFragId, CapsuleId, KFragId, SecretId, ShareCollectionId};
 pub use key_pair::KeyPair;
 pub use secret_data::SecretData;
-pub use symmetric_key::{SYMMETRIC_KEY_SIZE, SymmetricKey};
+pub use symmetric_key::{SymmetricKey, SYMMETRIC_KEY_SIZE};

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -19,8 +19,24 @@ pub trait ContractStorage: Send + Sync {
     /// Send kFrags to Owner-Process via AO Network
     async fn send_kfrags(&self, kfrags: &[KeyFragment], contract_id: &str) -> ServiceResult<()>;
 
-    /// Delegate capsule to contract (future use)
-    async fn delegate_capsule(&self, capsule_data: &[u8], contract_id: &str) -> ServiceResult<()>;
+    /// Delegate capsule to AO contract for re-encryption triggering
+    ///
+    /// Associates the Arweave capsule with its kFrag so the AO contract
+    /// can trigger Phase 2 re-encryption.
+    ///
+    /// # Arguments
+    /// * `capsule_data` - Serialized capsule bytes (from Arweave CapsulePayload)
+    /// * `contract_id` - Owner-Process contract ID on AO Network
+    /// * `kfrag_id`    - kFrag identifier matching the corresponding DelegateKFrag call
+    ///                   (format: `"kfrag-{index}"`)
+    /// * `capsule_id`  - Arweave transaction ID of the stored capsule (`capsule_tx_id`)
+    async fn delegate_capsule(
+        &self,
+        capsule_data: &[u8],
+        contract_id: &str,
+        kfrag_id: &str,
+        capsule_id: &str,
+    ) -> ServiceResult<()>;
 
     /// Retrieve cFrags for a secret from AO Network
     async fn retrieve_cfrags(
@@ -60,14 +76,21 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
 
     async fn delegate_capsule(
         &self,
-        _capsule_data: &[u8],
-        _contract_id: &str,
+        capsule_data: &[u8],
+        contract_id: &str,
+        kfrag_id: &str,
+        capsule_id: &str,
     ) -> ServiceResult<()> {
-        Err(ServiceError::System(
-            crate::service::error::SystemException::Internal(
-                "Not implemented: delegate_capsule".to_string(),
-            ),
-        ))
+        let msg = ExecuteMsg::DelegateCapsule {
+            kfrag_id: kfrag_id.to_string(),
+            capsule_id: capsule_id.to_string(),
+            capsule: Binary::from(capsule_data.to_vec()),
+        };
+        self.ao_client
+            .execute(contract_id, msg)
+            .await
+            .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
+        Ok(())
     }
 
     async fn retrieve_cfrags(

--- a/client/src/usecase/core/crypto.rs
+++ b/client/src/usecase/core/crypto.rs
@@ -4,12 +4,12 @@
 //! AO環境の制約に従い、すべての操作は同期的に実行されます。
 
 use aes_gcm::{
-    Aes256Gcm, Nonce,
     aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Nonce,
 };
 use bincode;
-use generic_array::{GenericArray, typenum::U32};
-use shamirsecretsharing::{DATA_SIZE, combine_shares, create_shares};
+use generic_array::{typenum::U32, GenericArray};
+use shamirsecretsharing::{combine_shares, create_shares, DATA_SIZE};
 use subtle::ConstantTimeEq;
 use umbral_pre::{self, DefaultDeserialize, DefaultSerialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/client/src/usecase/error.rs
+++ b/client/src/usecase/error.rs
@@ -263,6 +263,22 @@ pub enum WorkflowError {
         failed_count: usize,
         total_count: usize,
     },
+
+    /// DelegateCapsule to AO partially failed mid-loop (AO state may be inconsistent)
+    ///
+    /// Some kFrags were successfully delegated before the failure.
+    /// Retry is safe only if the AO contract treats DelegateCapsule as idempotent.
+    #[error("DelegateCapsule partial failure: {failed_count} of {total_count} kFrag delegations failed for capsule {capsule_tx_id}")]
+    PartialDelegateCapsuleFailure {
+        /// Arweave capsule tx ID (= `capsule_id` on AO contract)
+        capsule_tx_id: String,
+        /// kFrag IDs that were successfully delegated
+        successful_kfrag_ids: Vec<String>,
+        /// (kfrag_id, error_message) pairs for failed delegations
+        failed_kfrag_ids: Vec<(String, String)>,
+        failed_count: usize,
+        total_count: usize,
+    },
 }
 
 /// Conversion from ServiceError to WorkflowError
@@ -334,5 +350,22 @@ impl WorkflowError {
             self,
             Self::ValidationError(_) | Self::ResourceNotFound(_) | Self::InsufficientCFrags { .. }
         )
+    }
+
+    /// Create a partial DelegateCapsule failure error
+    pub fn partial_delegate_capsule_failure(
+        capsule_tx_id: impl Into<String>,
+        successful_kfrag_ids: Vec<String>,
+        failed_kfrag_ids: Vec<(String, String)>,
+    ) -> Self {
+        let failed_count = failed_kfrag_ids.len();
+        let total_count = successful_kfrag_ids.len() + failed_count;
+        Self::PartialDelegateCapsuleFailure {
+            capsule_tx_id: capsule_tx_id.into(),
+            successful_kfrag_ids,
+            failed_kfrag_ids,
+            failed_count,
+            total_count,
+        }
     }
 }

--- a/client/src/usecase/error.rs
+++ b/client/src/usecase/error.rs
@@ -266,12 +266,17 @@ pub enum WorkflowError {
 
     /// DelegateCapsule to AO partially failed mid-loop (AO state may be inconsistent)
     ///
-    /// Some kFrags were successfully delegated before the failure.
-    /// Retry is safe only if the AO contract treats DelegateCapsule as idempotent.
+    /// Encrypted shares and capsule **are safely stored on Arweave** (`share_tx_ids`
+    /// and `capsule_tx_id`). Only the AO delegation step had failures.
+    ///
+    /// Whether retry is safe depends on the AO contract's idempotency guarantee.
+    /// Consult the AO contract spec before retrying DelegateCapsule calls.
     #[error("DelegateCapsule partial failure: {failed_count} of {total_count} kFrag delegations failed for capsule {capsule_tx_id}")]
     PartialDelegateCapsuleFailure {
         /// Arweave capsule tx ID (= `capsule_id` on AO contract)
         capsule_tx_id: String,
+        /// Arweave share tx IDs — encrypted shares are stored even on failure
+        share_tx_ids: Vec<String>,
         /// kFrag IDs that were successfully delegated
         successful_kfrag_ids: Vec<String>,
         /// (kfrag_id, error_message) pairs for failed delegations
@@ -353,8 +358,12 @@ impl WorkflowError {
     }
 
     /// Create a partial DelegateCapsule failure error
+    ///
+    /// `share_tx_ids` should contain the Arweave tx IDs of encrypted shares that
+    /// were successfully stored, so callers know Arweave data is intact.
     pub fn partial_delegate_capsule_failure(
         capsule_tx_id: impl Into<String>,
+        share_tx_ids: Vec<String>,
         successful_kfrag_ids: Vec<String>,
         failed_kfrag_ids: Vec<(String, String)>,
     ) -> Self {
@@ -362,6 +371,7 @@ impl WorkflowError {
         let total_count = successful_kfrag_ids.len() + failed_count;
         Self::PartialDelegateCapsuleFailure {
             capsule_tx_id: capsule_tx_id.into(),
+            share_tx_ids,
             successful_kfrag_ids,
             failed_kfrag_ids,
             failed_count,

--- a/client/src/usecase/error.rs
+++ b/client/src/usecase/error.rs
@@ -264,14 +264,18 @@ pub enum WorkflowError {
         total_count: usize,
     },
 
-    /// DelegateCapsule to AO partially failed mid-loop (AO state may be inconsistent)
+    /// DelegateCapsule to AO partially failed after exhausting all retries.
     ///
     /// Encrypted shares and capsule **are safely stored on Arweave** (`share_tx_ids`
-    /// and `capsule_tx_id`). Only the AO delegation step had failures.
+    /// and `capsule_tx_id`). Only the AO delegation step had persistent failures.
     ///
-    /// Whether retry is safe depends on the AO contract's idempotency guarantee.
-    /// Consult the AO contract spec before retrying DelegateCapsule calls.
-    #[error("DelegateCapsule partial failure: {failed_count} of {total_count} kFrag delegations failed for capsule {capsule_tx_id}")]
+    /// **Retry safety:** The AO contract implements `IDEM_FLAGS` keyed on
+    /// `(process_id, kfrag_id, capsule_id)`. Successful delegations return `NoOp`
+    /// on re-submission; failed ones re-process cleanly from scratch. Manual retry
+    /// of the failed kFrags in `failed_kfrag_ids` is therefore safe.
+    /// Alternatively, use the AO `Reencrypt` message to trigger re-encryption for
+    /// capsules already stored in the holder contract.
+    #[error("DelegateCapsule partial failure: {failed_count} of {total_count} kFrag delegations failed after retries for capsule {capsule_tx_id}")]
     PartialDelegateCapsuleFailure {
         /// Arweave capsule tx ID (= `capsule_id` on AO contract)
         capsule_tx_id: String,

--- a/client/src/usecase/mod.rs
+++ b/client/src/usecase/mod.rs
@@ -15,8 +15,8 @@ pub use error::{
     BusinessException, ServiceError, ServiceResult, SystemException, WorkflowError, WorkflowResult,
 };
 pub use workflow::{
+    create_secret_recovery_service, create_secret_sharing_service, create_workflow_services,
     DefaultWorkflowServiceContainer, SecretRecoveryWorkflowService,
     SecretRecoveryWorkflowServiceImpl, SecretSharingWorkflowService,
-    SecretSharingWorkflowServiceImpl, WorkflowServiceContainer, create_secret_recovery_service,
-    create_secret_sharing_service, create_workflow_services,
+    SecretSharingWorkflowServiceImpl, WorkflowServiceContainer,
 };

--- a/client/src/usecase/service/storage_service.rs
+++ b/client/src/usecase/service/storage_service.rs
@@ -34,7 +34,13 @@ pub trait StorageService: Send + Sync {
         contract_id: &str,
     ) -> ServiceResult<()>;
 
-    async fn delegate_capsule(&self, capsule_data: &[u8], contract_id: &str) -> ServiceResult<()>;
+    async fn delegate_capsule(
+        &self,
+        capsule_data: &[u8],
+        contract_id: &str,
+        kfrag_id: &str,
+        capsule_id: &str,
+    ) -> ServiceResult<()>;
 
     async fn retrieve_cfrags(
         &self,
@@ -95,9 +101,15 @@ impl<S: ArweaveStorageService, CT: ContractStorage> StorageService for StorageSe
         self.contract.send_kfrags(kfrags, contract_id).await
     }
 
-    async fn delegate_capsule(&self, capsule_data: &[u8], contract_id: &str) -> ServiceResult<()> {
+    async fn delegate_capsule(
+        &self,
+        capsule_data: &[u8],
+        contract_id: &str,
+        kfrag_id: &str,
+        capsule_id: &str,
+    ) -> ServiceResult<()> {
         self.contract
-            .delegate_capsule(capsule_data, contract_id)
+            .delegate_capsule(capsule_data, contract_id, kfrag_id, capsule_id)
             .await
     }
 

--- a/client/src/usecase/workflow/mod.rs
+++ b/client/src/usecase/workflow/mod.rs
@@ -8,8 +8,8 @@ pub mod secret_recovery_service;
 pub mod secret_sharing_service;
 
 pub use container::{
-    DefaultWorkflowServiceContainer, WorkflowServiceContainer, create_secret_recovery_service,
-    create_secret_sharing_service, create_workflow_services,
+    create_secret_recovery_service, create_secret_sharing_service, create_workflow_services,
+    DefaultWorkflowServiceContainer, WorkflowServiceContainer,
 };
 pub use secret_recovery_service::{
     SecretRecoveryWorkflowService, SecretRecoveryWorkflowServiceImpl,

--- a/client/src/usecase/workflow/secret_recovery_service.rs
+++ b/client/src/usecase/workflow/secret_recovery_service.rs
@@ -106,11 +106,16 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowServiceImpl<C, 
             .map_err(WorkflowError::from)
     }
 
-    /// Retrieve Capsule, ciphertext, verifying_pk, and threshold from Arweave
+    /// Retrieve Capsule, ciphertext, verifying_pk, thresholds, and capsule_tx_id from Arweave
+    ///
+    /// Returns `(capsule, ciphertext, verifying_pk, threshold_k, threshold_n, capsule_tx_id)`.
+    /// - `threshold_k` – minimum kFrags required for reconstruction
+    /// - `threshold_n` – total kFrags generated (stored for audit / future use)
+    /// - `capsule_tx_id` – Arweave transaction ID of the stored capsule (= `capsule_id` for AO)
     fn retrieve_capsule_with_metadata(
         &self,
         secret_id: &SecretId,
-    ) -> WorkflowResult<(Capsule, Vec<u8>, Vec<u8>, u8)> {
+    ) -> WorkflowResult<(Capsule, Vec<u8>, Vec<u8>, u8, u8, String)> {
         // Phase 1 stores exactly one capsule per secret_id (UUID v4), so limit=1
         // with no sort is safe. See CapsuleRepository.find_by_secret_id -> Option<Capsule>.
         let params = QueryParams {
@@ -137,6 +142,8 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowServiceImpl<C, 
             WorkflowError::not_found(format!("Capsule not found for secret {secret_id}"))
         })?;
 
+        let capsule_tx_id = tx.id.clone();
+
         let threshold_k = tx
             .tags
             .iter()
@@ -147,6 +154,17 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowServiceImpl<C, 
             .value
             .parse::<u8>()
             .map_err(|e| WorkflowError::validation(format!("Invalid threshold_k value: {e}")))?;
+
+        let threshold_n = tx
+            .tags
+            .iter()
+            .find(|t| t.name == "threshold_n")
+            .ok_or_else(|| {
+                WorkflowError::not_found("threshold_n tag missing from capsule transaction")
+            })?
+            .value
+            .parse::<u8>()
+            .map_err(|e| WorkflowError::validation(format!("Invalid threshold_n value: {e}")))?;
 
         let payload: CapsulePayload = bincode::deserialize(&tx.data)
             .map_err(|_| WorkflowError::crypto("Failed to deserialize CapsulePayload"))?;
@@ -160,6 +178,8 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowServiceImpl<C, 
             payload.ciphertext,
             payload.verifying_pk,
             threshold_k,
+            threshold_n,
+            capsule_tx_id,
         ))
     }
 
@@ -277,7 +297,9 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowService
             .await?;
 
         // Step 2: Retrieve CapsulePayload (capsule + ciphertext + verifying_pk) from Arweave
-        let (capsule, ciphertext, verifying_pk, threshold) =
+        // capsule_tx_id is the Arweave tx ID of the capsule (= capsule_id on AO contract side)
+        // threshold_n is stored for audit / future use
+        let (capsule, ciphertext, verifying_pk, threshold, _threshold_n, _capsule_tx_id) =
             self.retrieve_capsule_with_metadata(&request.secret_id)?;
 
         // Step 3: Retrieve encrypted shares and verify threshold
@@ -315,7 +337,7 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowService
         secret_id: &SecretId,
         requester_process_id: &str,
     ) -> WorkflowResult<bool> {
-        let (_, _, _, threshold) = self.retrieve_capsule_with_metadata(secret_id)?;
+        let (_, _, _, threshold, _, _) = self.retrieve_capsule_with_metadata(secret_id)?;
 
         // Retrieve available cFrags
         let cfrags = self

--- a/client/src/usecase/workflow/secret_recovery_service.rs
+++ b/client/src/usecase/workflow/secret_recovery_service.rs
@@ -155,16 +155,14 @@ impl<C: CryptoService, ST: StorageService> SecretRecoveryWorkflowServiceImpl<C, 
             .parse::<u8>()
             .map_err(|e| WorkflowError::validation(format!("Invalid threshold_k value: {e}")))?;
 
+        // threshold_n may be absent on capsules created before this tag was introduced.
+        // Falling back to threshold_k is safe (n >= k always; using k as the lower bound).
         let threshold_n = tx
             .tags
             .iter()
             .find(|t| t.name == "threshold_n")
-            .ok_or_else(|| {
-                WorkflowError::not_found("threshold_n tag missing from capsule transaction")
-            })?
-            .value
-            .parse::<u8>()
-            .map_err(|e| WorkflowError::validation(format!("Invalid threshold_n value: {e}")))?;
+            .and_then(|t| t.value.parse::<u8>().ok())
+            .unwrap_or(threshold_k);
 
         let payload: CapsulePayload = bincode::deserialize(&tx.data)
             .map_err(|_| WorkflowError::crypto("Failed to deserialize CapsulePayload"))?;

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroizing;
 
 use crate::domain::value_objects::SecretId;
 use crate::usecase::core::crypto::{
-    CapsulePayload, KeyFragment, PublicKey, ShamirShare, constants,
+    constants, CapsulePayload, KeyFragment, PublicKey, ShamirShare,
 };
 use crate::usecase::core::storage::{QueryParams, Tag};
 use crate::usecase::dto::{SecretSharingRequest, SecretSharingResult, SecretStatus};
@@ -359,8 +359,7 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
             for attempt in 0..=DELEGATE_CAPSULE_MAX_RETRIES {
                 if attempt > 0 {
                     // Exponential backoff: 100ms, 200ms, 400ms
-                    let delay_ms =
-                        DELEGATE_CAPSULE_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 1));
+                    let delay_ms = DELEGATE_CAPSULE_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 1));
                     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 }
 

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -4,6 +4,7 @@
 //! PHASE 1 workflow: secret splitting, encryption, kFrag generation, and storage.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use zeroize::Zeroizing;
@@ -16,6 +17,17 @@ use crate::usecase::core::storage::{QueryParams, Tag};
 use crate::usecase::dto::{SecretSharingRequest, SecretSharingResult, SecretStatus};
 use crate::usecase::error::{WorkflowError, WorkflowResult};
 use crate::usecase::service::{CryptoService, StorageService};
+
+// ============================================================================
+// DelegateCapsule Retry Config
+// ============================================================================
+
+/// Maximum number of retries for each DelegateCapsule call (excluding the initial attempt).
+/// AO contract uses IDEM_FLAGS to ensure idempotency on success; retries on failure are safe.
+const DELEGATE_CAPSULE_MAX_RETRIES: u32 = 3;
+
+/// Base delay for exponential backoff (doubles each retry: 100ms → 200ms → 400ms).
+const DELEGATE_CAPSULE_RETRY_BASE_DELAY_MS: u64 = 100;
 
 // ============================================================================
 // SecretSharingWorkflowService Trait
@@ -333,26 +345,49 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
         // Called AFTER both capsule and shares are safely on Arweave (Steps 8 & 9).
         // This prevents AO from triggering re-encryption before shares are available.
         //
-        // All kFrags are attempted even on partial failure so we know exactly
-        // which delegations succeeded/failed (AO has no rollback).
-        // share_tx_ids is included in the error so callers know Arweave is intact.
+        // Retry with exponential backoff per kFrag (safe because the AO contract
+        // implements IDEM_FLAGS: successful calls return NoOp on re-submission,
+        // failed calls re-process cleanly from scratch).
+        // share_tx_ids is included in any error so callers know Arweave is intact.
         let mut delegate_successful_ids: Vec<String> = Vec::with_capacity(kfrags.len());
         let mut delegate_failed_ids: Vec<(String, String)> = Vec::new();
 
         for kfrag in &kfrags {
             let kfrag_id = format!("kfrag-{}", kfrag.id);
-            match self
-                .storage_service
-                .delegate_capsule(
-                    &capsule.capsule_bytes,
-                    &request.owner_process_id,
-                    &kfrag_id,
-                    &capsule_tx_id,
-                )
-                .await
-            {
-                Ok(()) => delegate_successful_ids.push(kfrag_id),
-                Err(e) => delegate_failed_ids.push((kfrag_id, e.to_string())),
+            let mut last_err: Option<String> = None;
+
+            for attempt in 0..=DELEGATE_CAPSULE_MAX_RETRIES {
+                if attempt > 0 {
+                    // Exponential backoff: 100ms, 200ms, 400ms
+                    let delay_ms =
+                        DELEGATE_CAPSULE_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 1));
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+
+                match self
+                    .storage_service
+                    .delegate_capsule(
+                        &capsule.capsule_bytes,
+                        &request.owner_process_id,
+                        &kfrag_id,
+                        &capsule_tx_id,
+                    )
+                    .await
+                {
+                    Ok(()) => {
+                        last_err = None;
+                        break; // success — stop retrying this kFrag
+                    }
+                    Err(e) => {
+                        last_err = Some(e.to_string());
+                        // continue to next attempt
+                    }
+                }
+            }
+
+            match last_err {
+                None => delegate_successful_ids.push(kfrag_id),
+                Some(err) => delegate_failed_ids.push((kfrag_id, err)),
             }
         }
 

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -283,41 +283,38 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
 
         // Step 8b: DelegateCapsule to AO for each kFrag
         //
-        // This triggers Phase 2 re-encryption on the AO contract side.
-        // Must be done after Step 8 because capsule_tx_id (Arweave tx) is required.
+        // Triggers Phase 2 re-encryption on the AO contract side.
+        // Must run after Step 8 because capsule_tx_id (Arweave tx) is required.
         //
-        // All kFrags are attempted even if some fail, so we can report exactly
-        // which delegations succeeded/failed (AO state has no rollback).
-        {
-            let mut successful_kfrag_ids: Vec<String> = Vec::with_capacity(kfrags.len());
-            let mut failed_kfrag_ids: Vec<(String, String)> = Vec::new();
+        // All kFrags are attempted even on partial failure so we know exactly
+        // which delegations succeeded/failed (AO has no rollback).
+        //
+        // NOTE: We intentionally do NOT return early here.
+        // Encrypted shares (Step 9) must be stored on Arweave regardless of AO
+        // outcome — otherwise a temporary AO failure would permanently orphan the
+        // capsule and leave shares unrecoverable.
+        let mut delegate_successful_ids: Vec<String> = Vec::with_capacity(kfrags.len());
+        let mut delegate_failed_ids: Vec<(String, String)> = Vec::new();
 
-            for kfrag in &kfrags {
-                let kfrag_id = format!("kfrag-{}", kfrag.id);
-                match self
-                    .storage_service
-                    .delegate_capsule(
-                        &capsule.capsule_bytes,
-                        &request.owner_process_id,
-                        &kfrag_id,
-                        &capsule_tx_id,
-                    )
-                    .await
-                {
-                    Ok(()) => successful_kfrag_ids.push(kfrag_id),
-                    Err(e) => failed_kfrag_ids.push((kfrag_id, e.to_string())),
-                }
-            }
-
-            if !failed_kfrag_ids.is_empty() {
-                return Err(WorkflowError::partial_delegate_capsule_failure(
+        for kfrag in &kfrags {
+            let kfrag_id = format!("kfrag-{}", kfrag.id);
+            match self
+                .storage_service
+                .delegate_capsule(
+                    &capsule.capsule_bytes,
+                    &request.owner_process_id,
+                    &kfrag_id,
                     &capsule_tx_id,
-                    successful_kfrag_ids,
-                    failed_kfrag_ids,
-                ));
+                )
+                .await
+            {
+                Ok(()) => delegate_successful_ids.push(kfrag_id),
+                Err(e) => delegate_failed_ids.push((kfrag_id, e.to_string())),
             }
         }
 
+        // Step 9: Store encrypted shares on Arweave
+        // Always runs — AO failures above do not skip share storage.
         let share_items: Vec<(Vec<u8>, Vec<Tag>)> = encrypted_shares
             .into_iter()
             .enumerate()
@@ -358,6 +355,17 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
             });
         }
         let share_tx_ids = batch_result.successful;
+
+        // Now that shares are safely stored, surface any DelegateCapsule failures.
+        // share_tx_ids is included so the caller knows Arweave data is intact.
+        if !delegate_failed_ids.is_empty() {
+            return Err(WorkflowError::partial_delegate_capsule_failure(
+                &capsule_tx_id,
+                share_tx_ids,
+                delegate_successful_ids,
+                delegate_failed_ids,
+            ));
+        }
 
         Ok(SecretSharingResult {
             secret_id,

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -285,16 +285,37 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
         //
         // This triggers Phase 2 re-encryption on the AO contract side.
         // Must be done after Step 8 because capsule_tx_id (Arweave tx) is required.
-        for kfrag in &kfrags {
-            self.storage_service
-                .delegate_capsule(
-                    &capsule.capsule_bytes,
-                    &request.owner_process_id,
-                    &format!("kfrag-{}", kfrag.id),
+        //
+        // All kFrags are attempted even if some fail, so we can report exactly
+        // which delegations succeeded/failed (AO state has no rollback).
+        {
+            let mut successful_kfrag_ids: Vec<String> = Vec::with_capacity(kfrags.len());
+            let mut failed_kfrag_ids: Vec<(String, String)> = Vec::new();
+
+            for kfrag in &kfrags {
+                let kfrag_id = format!("kfrag-{}", kfrag.id);
+                match self
+                    .storage_service
+                    .delegate_capsule(
+                        &capsule.capsule_bytes,
+                        &request.owner_process_id,
+                        &kfrag_id,
+                        &capsule_tx_id,
+                    )
+                    .await
+                {
+                    Ok(()) => successful_kfrag_ids.push(kfrag_id),
+                    Err(e) => failed_kfrag_ids.push((kfrag_id, e.to_string())),
+                }
+            }
+
+            if !failed_kfrag_ids.is_empty() {
+                return Err(WorkflowError::partial_delegate_capsule_failure(
                     &capsule_tx_id,
-                )
-                .await
-                .map_err(WorkflowError::from)?;
+                    successful_kfrag_ids,
+                    failed_kfrag_ids,
+                ));
+            }
         }
 
         let share_items: Vec<(Vec<u8>, Vec<Tag>)> = encrypted_shares

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -281,40 +281,12 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
             )
             .map_err(WorkflowError::from)?;
 
-        // Step 8b: DelegateCapsule to AO for each kFrag
-        //
-        // Triggers Phase 2 re-encryption on the AO contract side.
-        // Must run after Step 8 because capsule_tx_id (Arweave tx) is required.
-        //
-        // All kFrags are attempted even on partial failure so we know exactly
-        // which delegations succeeded/failed (AO has no rollback).
-        //
-        // NOTE: We intentionally do NOT return early here.
-        // Encrypted shares (Step 9) must be stored on Arweave regardless of AO
-        // outcome — otherwise a temporary AO failure would permanently orphan the
-        // capsule and leave shares unrecoverable.
-        let mut delegate_successful_ids: Vec<String> = Vec::with_capacity(kfrags.len());
-        let mut delegate_failed_ids: Vec<(String, String)> = Vec::new();
-
-        for kfrag in &kfrags {
-            let kfrag_id = format!("kfrag-{}", kfrag.id);
-            match self
-                .storage_service
-                .delegate_capsule(
-                    &capsule.capsule_bytes,
-                    &request.owner_process_id,
-                    &kfrag_id,
-                    &capsule_tx_id,
-                )
-                .await
-            {
-                Ok(()) => delegate_successful_ids.push(kfrag_id),
-                Err(e) => delegate_failed_ids.push((kfrag_id, e.to_string())),
-            }
-        }
-
         // Step 9: Store encrypted shares on Arweave
-        // Always runs — AO failures above do not skip share storage.
+        //
+        // Shares are stored BEFORE DelegateCapsule (Step 9b) to ensure all
+        // Arweave data (capsule + shares) is durable before the AO contract is
+        // notified. If AO triggers re-encryption immediately on DelegateCapsule,
+        // the shares must already be available for Phase 3 retrieval.
         let share_items: Vec<(Vec<u8>, Vec<Tag>)> = encrypted_shares
             .into_iter()
             .enumerate()
@@ -356,8 +328,34 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
         }
         let share_tx_ids = batch_result.successful;
 
-        // Now that shares are safely stored, surface any DelegateCapsule failures.
-        // share_tx_ids is included so the caller knows Arweave data is intact.
+        // Step 9b: DelegateCapsule to AO for each kFrag
+        //
+        // Called AFTER both capsule and shares are safely on Arweave (Steps 8 & 9).
+        // This prevents AO from triggering re-encryption before shares are available.
+        //
+        // All kFrags are attempted even on partial failure so we know exactly
+        // which delegations succeeded/failed (AO has no rollback).
+        // share_tx_ids is included in the error so callers know Arweave is intact.
+        let mut delegate_successful_ids: Vec<String> = Vec::with_capacity(kfrags.len());
+        let mut delegate_failed_ids: Vec<(String, String)> = Vec::new();
+
+        for kfrag in &kfrags {
+            let kfrag_id = format!("kfrag-{}", kfrag.id);
+            match self
+                .storage_service
+                .delegate_capsule(
+                    &capsule.capsule_bytes,
+                    &request.owner_process_id,
+                    &kfrag_id,
+                    &capsule_tx_id,
+                )
+                .await
+            {
+                Ok(()) => delegate_successful_ids.push(kfrag_id),
+                Err(e) => delegate_failed_ids.push((kfrag_id, e.to_string())),
+            }
+        }
+
         if !delegate_failed_ids.is_empty() {
             return Err(WorkflowError::partial_delegate_capsule_failure(
                 &capsule_tx_id,

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -281,6 +281,22 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
             )
             .map_err(WorkflowError::from)?;
 
+        // Step 8b: DelegateCapsule to AO for each kFrag
+        //
+        // This triggers Phase 2 re-encryption on the AO contract side.
+        // Must be done after Step 8 because capsule_tx_id (Arweave tx) is required.
+        for kfrag in &kfrags {
+            self.storage_service
+                .delegate_capsule(
+                    &capsule.capsule_bytes,
+                    &request.owner_process_id,
+                    &format!("kfrag-{}", kfrag.id),
+                    &capsule_tx_id,
+                )
+                .await
+                .map_err(WorkflowError::from)?;
+        }
+
         let share_items: Vec<(Vec<u8>, Vec<Tag>)> = encrypted_shares
             .into_iter()
             .enumerate()

--- a/client/tests/integration/secret_recovery_workflow_test.rs
+++ b/client/tests/integration/secret_recovery_workflow_test.rs
@@ -28,8 +28,8 @@ type TestStorageService =
     ServiceStorageServiceImpl<ArweaveStorageServiceImpl, ContractStorageImpl<MockAOClient>>;
 
 /// Helper to create test service with real CryptoService
-fn create_integration_service()
--> SecretRecoveryWorkflowServiceImpl<TestCryptoService, TestStorageService> {
+fn create_integration_service(
+) -> SecretRecoveryWorkflowServiceImpl<TestCryptoService, TestStorageService> {
     let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
     let crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());

--- a/client/tests/integration/secret_sharing_workflow_test.rs
+++ b/client/tests/integration/secret_sharing_workflow_test.rs
@@ -21,8 +21,8 @@ type TestStorageService =
     ServiceStorageServiceImpl<ArweaveStorageServiceImpl, ContractStorageImpl<MockAOClient>>;
 
 /// Helper to create test service with real CryptoService
-fn create_integration_service()
--> SecretSharingWorkflowServiceImpl<TestCryptoService, TestStorageService> {
+fn create_integration_service(
+) -> SecretSharingWorkflowServiceImpl<TestCryptoService, TestStorageService> {
     let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
     let crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());

--- a/client/tests/integration/workflow_roundtrip_test.rs
+++ b/client/tests/integration/workflow_roundtrip_test.rs
@@ -11,7 +11,6 @@
 use std::sync::Arc;
 
 use formix::adapter::external::mock_ao::MockAOClient;
-use formix::usecase::SecretSharingRequest;
 use formix::usecase::core::contract_storage::ContractStorageImpl;
 use formix::usecase::core::crypto::{
     CryptoService, CryptoServiceImpl as CoreCryptoServiceImpl, ShamirShare,
@@ -21,6 +20,7 @@ use formix::usecase::service::{
     CryptoServiceImpl as ServiceCryptoServiceImpl, StorageServiceImpl as ServiceStorageServiceImpl,
 };
 use formix::usecase::workflow::{SecretSharingWorkflowService, SecretSharingWorkflowServiceImpl};
+use formix::usecase::SecretSharingRequest;
 
 // ============================================================================
 // PHASE 1 → PHASE 3 Roundtrip Tests (Task 22)

--- a/client/tests/unit/adapter/external/ao/data_item.rs
+++ b/client/tests/unit/adapter/external/ao/data_item.rs
@@ -4,11 +4,11 @@ use formix::adapter::external::ao::{
 
 #[allow(clippy::many_single_char_names)]
 fn test_jwk() -> ArweaveJWK {
-    use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
     use rand::rngs::OsRng;
-    use rsa::RsaPrivateKey;
     use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+    use rsa::RsaPrivateKey;
 
     let private_key = RsaPrivateKey::new(&mut OsRng, 4096).unwrap();
     let public_key = private_key.to_public_key();

--- a/client/tests/unit/adapter/external/ao/production_client.rs
+++ b/client/tests/unit/adapter/external/ao/production_client.rs
@@ -7,11 +7,11 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[allow(clippy::many_single_char_names)]
 fn test_jwk() -> ArweaveJWK {
-    use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
     use rand::rngs::OsRng;
-    use rsa::RsaPrivateKey;
     use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+    use rsa::RsaPrivateKey;
 
     let private_key = RsaPrivateKey::new(&mut OsRng, 4096).unwrap();
     let public_key = private_key.to_public_key();

--- a/client/tests/unit/controller/error.rs
+++ b/client/tests/unit/controller/error.rs
@@ -1,4 +1,4 @@
-use formix::controller::{MAX_SHARES, MIN_THRESHOLD, ValidationError, error_codes};
+use formix::controller::{error_codes, ValidationError, MAX_SHARES, MIN_THRESHOLD};
 use formix::usecase::error::WorkflowError;
 
 #[test]

--- a/client/tests/unit/controller/validator.rs
+++ b/client/tests/unit/controller/validator.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use formix::controller::{
-    MAX_SHARES, MIN_THRESHOLD, RecoverValidator, ShareValidator, error_codes,
+    error_codes, RecoverValidator, ShareValidator, MAX_SHARES, MIN_THRESHOLD,
 };
 use formix::usecase::core::crypto::{CryptoService, CryptoServiceImpl};
 

--- a/client/tests/unit/domain/value_objects/symmetric_key.rs
+++ b/client/tests/unit/domain/value_objects/symmetric_key.rs
@@ -1,4 +1,4 @@
-use formix::domain::{SYMMETRIC_KEY_SIZE, SymmetricKey};
+use formix::domain::{SymmetricKey, SYMMETRIC_KEY_SIZE};
 
 #[test]
 fn test_symmetric_key_new() {

--- a/client/tests/unit/usecase/core/crypto.rs
+++ b/client/tests/unit/usecase/core/crypto.rs
@@ -1,4 +1,4 @@
-use formix::usecase::core::crypto::{CryptoService, CryptoServiceImpl, constants};
+use formix::usecase::core::crypto::{constants, CryptoService, CryptoServiceImpl};
 
 #[test]
 fn test_create_kfrags() {

--- a/client/tests/unit/usecase/error.rs
+++ b/client/tests/unit/usecase/error.rs
@@ -177,16 +177,14 @@ fn test_workflow_error_is_recoverable() {
     assert!(!WorkflowError::storage("test").is_recoverable());
     assert!(!WorkflowError::ao_communication("test").is_recoverable());
     assert!(!WorkflowError::decryption("test").is_recoverable());
-    assert!(
-        !WorkflowError::PartialStorageFailure {
-            capsule_tx_id: "tx".to_string(),
-            successful_share_tx_ids: vec![],
-            failed_shares: vec![],
-            failed_count: 0,
-            total_count: 0,
-        }
-        .is_recoverable()
-    );
+    assert!(!WorkflowError::PartialStorageFailure {
+        capsule_tx_id: "tx".to_string(),
+        successful_share_tx_ids: vec![],
+        failed_shares: vec![],
+        failed_count: 0,
+        total_count: 0,
+    }
+    .is_recoverable());
 }
 
 #[test]

--- a/client/tests/unit/usecase/workflow/container.rs
+++ b/client/tests/unit/usecase/workflow/container.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use formix::usecase::workflow::{
-    DefaultWorkflowServiceContainer, create_secret_recovery_service, create_secret_sharing_service,
-    create_workflow_services,
+    create_secret_recovery_service, create_secret_sharing_service, create_workflow_services,
+    DefaultWorkflowServiceContainer,
 };
 
 #[test]

--- a/client/tests/unit/usecase/workflow/secret_sharing_service.rs
+++ b/client/tests/unit/usecase/workflow/secret_sharing_service.rs
@@ -4,7 +4,7 @@ use formix::adapter::external::mock_ao::MockAOClient;
 use formix::domain::SecretId;
 use formix::usecase::core::contract_storage::ContractStorageImpl;
 use formix::usecase::core::crypto::{
-    CryptoService as CoreCryptoService, CryptoServiceImpl as CoreCryptoServiceImpl, constants,
+    constants, CryptoService as CoreCryptoService, CryptoServiceImpl as CoreCryptoServiceImpl,
 };
 use formix::usecase::core::storage::ArweaveStorageServiceImpl;
 use formix::usecase::dto::SecretSharingRequest;


### PR DESCRIPTION
## 概要

Issue #70 の3点の修正を実装。

Phase 1 → Phase 2（再暗号化）→ Phase 3 の連鎖が壊れている根本原因を修正。

---

## 修正① `ContractStorage::delegate_capsule` シグネチャ変更

`kfrag_id` / `capsule_id` パラメータを追加し、`ExecuteMsg::DelegateCapsule` を実際に呼び出す実装に変更。

```rust
// Before
async fn delegate_capsule(&self, capsule_data: &[u8], contract_id: &str) -> ServiceResult<()>;
// → "Not implemented" エラーを返すだけ

// After
async fn delegate_capsule(
    &self,
    capsule_data: &[u8],
    contract_id: &str,
    kfrag_id: &str,
    capsule_id: &str,
) -> ServiceResult<()>;
```

## 修正② Phase 1 に `DelegateCapsule` 呼び出しを追加

`capsule_tx_id` 取得後、各 kFrag に対して `DelegateCapsule` を送信するループを追加。

```rust
// Step 8b: DelegateCapsule to AO for each kFrag
for kfrag in &kfrags {
    self.storage_service
        .delegate_capsule(
            &capsule.capsule_bytes,
            &request.owner_process_id,
            &format!("kfrag-{}", kfrag.id), // DelegateKFrag と同形式
            &capsule_tx_id,                 // Arweave の capsule tx ID
        )
        .await
        .map_err(WorkflowError::from)?;
}
```

## 修正③ `retrieve_capsule_with_metadata` の返り値拡張

`capsule_tx_id`（Arweave `tx.id`）と `threshold_n` を追加返却。

```rust
// Before: (Capsule, Vec<u8>, Vec<u8>, u8)
// After:  (Capsule, Vec<u8>, Vec<u8>, u8, u8, String)
//                                   ^k  ^n  ^capsule_tx_id
```

---

## 変更ファイル

- `client/src/usecase/core/contract_storage.rs`
- `client/src/usecase/service/storage_service.rs`
- `client/src/usecase/workflow/secret_sharing_service.rs`
- `client/src/usecase/workflow/secret_recovery_service.rs`

Closes #70