### PR TITLE
refactor(client): external/ao → ao_cwao + HyperBEAM-native ao/ scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /target
 demo/target/
+ao/contracts/target/
+ao/contracts/Cargo.lock
+
+**/node_modules/
 
 **/tmp_pr_description.md
 
@@ -8,6 +12,9 @@ demo/.env
 demo/deploy.json
 demo/wallet.json
 ao/wallet.json
+demo/arweave-keyfile.json
+
+ao/logs
 
 .serena/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,23 @@ All processes use the same Wasm binary deployed to Arweave, with role differenti
 - **Formatting**: 100 character line width, 4 spaces, Unix newlines
 - **Linting**: Aggressive clippy configuration with specific allowances for development phase
 
-## AO Stateless Execution Constraints
+## AO Execution Constraints
 
-**Critical for FORMIX**: The AO Network executes processes statelessly with specific constraints:
+FORMIX targets two AO runtimes with different state models:
+
+### HyperBEAM-native (`ao/contracts/src/`) — WASM memory snapshots
+
+HyperBEAM's `~wasm64@1.0` device snapshots the entire WASM linear memory after
+each message and restores it before the next. This means **global Rust statics
+persist across invocations** — no explicit load/save to Arweave is needed.
+
+- State is kept in `static` globals using `UnsafeCell` (safe because WASM is single-threaded)
+- No CosmWasm host functions (`db_read`/`db_write`)
+- Entry point: `handle(msg_ptr, msg_len) -> i32`
+
+### CWAO (`ao_cwao/contracts/src/`) — CosmWasm-style persistence
+
+The legacy CWAO runtime is stateless between messages:
 
 1. **Memory Non-Persistence Between Messages**
    - Each message execution starts with clean memory
@@ -159,31 +173,17 @@ All processes use the same Wasm binary deployed to Arweave, with role differenti
    - No shared memory between executions
    - State consistency must be maintained through persistence
 
-3. **Synchronous-Only Execution**
+### Shared Constraints (both runtimes)
+
+1. **Synchronous-Only Execution**
    - async/await is not available in AO environment
    - All operations must be blocking
    - Error handling must be synchronous
 
-4. **Message-Driven Architecture**
+2. **Message-Driven Architecture**
    - All processing is triggered by messages
    - UseCase handlers are entry points
    - State transitions must be atomic per message
-
-### Required Message Handler Pattern
-```rust
-pub fn handle_message(msg: AOMessage, repo: &dyn Repository) -> Result<Response> {
-    // 1. Load state
-    let mut state = repo.load_state(msg.process_id)?;
-    
-    // 2. Process message
-    let result = process_with_state(&mut state, msg)?;
-    
-    // 3. Persist state
-    repo.save_state(msg.process_id, &state)?;
-    
-    Ok(result)
-}
-```
 
 ## Directory-Specific Async Policy
 
@@ -192,10 +192,11 @@ FORMIX has two Rust codebases with different async constraints:
 | Directory | async/await | tokio | Reason |
 |-----------|------------|-------|--------|
 | `ao/contracts/src/` | Prohibited | Not available | AO WASM single-threaded constraint |
+| `ao_cwao/contracts/src/` | Prohibited | Not available | AO WASM single-threaded constraint |
 | `client/` | Required for I/O | Available (non-wasm32) | Client-side library with network operations |
 
-### `ao/contracts/src/` - Sync Only
-The "AO Stateless Execution Constraints" above apply exclusively to this directory.
+### `ao/contracts/src/` and `ao_cwao/contracts/src/` - Sync Only
+The "AO Execution Constraints" above apply exclusively to these directories.
 
 ### `client/` - Async for Network I/O
 - `AOClient` trait uses `#[async_trait]` - all AO Network calls are async

--- a/ao/README.md
+++ b/ao/README.md
@@ -2,6 +2,12 @@
 
 AO-native Rust WASMコントラクト。旧来の`ao_cwao/`（CosmWasm版）をHyperBEAM (`~wasm64@1.0`) 向けに再設計。
 
+Umbral Proxy Re-Encryption (PRE) をオンチェーンで実行し、閾値分散鍵管理を実現する。
+クライアントライブラリ (`client/`) の `AOExecuteMsg` / `AOQueryMsg` がこのコントラクトのメッセージインターフェースに対応する。
+kFrag ペイロードは `bincode::serialize::<StoredKeyFrag>(...)` 形式で送信する必要がある（詳細は `client/src/usecase/core/contract_storage.rs` の `StoredKeyFragPayload` を参照）。
+
+---
+
 ## 旧バージョンとの違い
 
 | 項目 | `ao_cwao/` (legacy) | `ao/` (this) |
@@ -15,6 +21,8 @@ AO-native Rust WASMコントラクト。旧来の`ao_cwao/`（CosmWasm版）をH
 | クロスコントラクト | `SubMsg` (同期) | `OutgoingMessage` (AO async message) |
 | 暗号ライブラリ | `umbral-pre` (unchanged) | `umbral-pre` (unchanged) |
 
+---
+
 ## ディレクトリ構成
 
 ```
@@ -22,14 +30,196 @@ ao/
 ├── contracts/              # Rust WASM contract
 │   ├── Cargo.toml
 │   └── src/
-│       ├── lib.rs          # WASM entry point (handle fn)
-│       ├── handlers.rs     # Business logic (dispatch + re-encryption)
-│       ├── state.rs        # ProcessState (replaces CosmWasm storage maps)
-│       ├── message.rs      # AOMessage / AOResponse types
-│       └── getrandom_impl.rs  # Custom WASM getrandom
+│       ├── lib.rs              # WASM entry point (handle fn)
+│       ├── handlers.rs         # Business logic (dispatch + 9 handlers)
+│       ├── state.rs            # ProcessState, ProcessRole, StoredKeyFrag, StoredCFrag
+│       ├── message.rs          # AOMessage / AOResponse / OutgoingMessage
+│       └── getrandom_impl.rs   # Custom WASM getrandom (placeholder)
 └── scripts/
     └── deploy.js           # HyperBEAM deployment via @permaweb/aoconnect
 ```
+
+---
+
+## プロセスロール
+
+各 AO プロセスは `Init` メッセージで以下のいずれかのロールを割り当てられる。
+
+| ロール | 説明 | 許可アクション |
+|--------|------|----------------|
+| **Owner** | 秘密鍵の保持者。kFrag/Capsule を Holder に委任する | `DelegateKFrag`, `DelegateCapsule` |
+| **Holder** | kFrag を受領し、再暗号化を実行する | `SubmitKFrag`, `SubmitCapsule`, `Reencrypt` |
+| **Requester** | cFrag を取得する（将来拡張用） | Query のみ |
+| **Combined** | Owner + Holder の全アクションを許可 | 上記すべて |
+
+Query アクション (`GetCFrag`, `ListCapsules`) は初期化済みの全ロールで利用可能。
+
+### Combined ロール
+
+単一プロセスで Owner と Holder の両方の機能を実行するモード。
+
+**ユースケース:**
+- テスト・開発環境でのシンプルな構成
+- 少数ノード環境（Holder を別プロセスに分離するオーバーヘッドが不要な場合）
+- クライアントの `ContractStorageImpl::new_single_process()` が使用するデフォルトモード
+
+**制約:**
+- セキュリティ上、本番環境では Owner と Holder を分離することを推奨（PRD §4）
+- Combined プロセスは全 Owner/Holder アクションを受け付けるため、ロール分離による権限制限が無効になる
+
+---
+
+## WASM ABI & 状態管理
+
+### エントリポイント
+
+| 関数 | シグネチャ | 説明 |
+|------|-----------|------|
+| `handle` | `(msg_ptr: i32, msg_len: i32) -> i32` | メインエントリ。JSON メッセージを受け取り、JSON レスポンスのポインタを返す |
+| `alloc` | `(size: i32) -> i32` | ホストがメッセージ書き込み用にWASMメモリを確保する |
+| `dealloc` | `(ptr: i32, size: i32)` | ホストが確保したメモリを解放する |
+| `response_len` | `() -> i32` | 最後のレスポンスのバイト長を返す（ホストが ptr..ptr+len を読む） |
+
+### 状態管理: SyncCell パターン
+
+HyperBEAM の `~wasm64@1.0` デバイスは、各メッセージ処理後に WASM リニアメモリ全体をスナップショットし、次のメッセージ処理前に復元する。これにより **Rust の `static` グローバル変数がメッセージ間で永続化される**。
+
+```rust
+// Safety: WASM はシングルスレッド。並行アクセスは発生しない。
+// UnsafeCell + 手動 Sync で Rust 2024 の static_mut_refs 禁止ルールに対応。
+struct SyncCell<T>(UnsafeCell<T>);
+unsafe impl<T> Sync for SyncCell<T> {}
+
+static PROCESS_STATE: SyncCell<Option<ProcessState>> = SyncCell(UnsafeCell::new(None));
+static RESPONSE_BUF: SyncCell<Vec<u8>> = SyncCell(UnsafeCell::new(Vec::new()));
+```
+
+**Safety 根拠:**
+- WASM は仕様上シングルスレッド実行。`Send`/`Sync` の並行性保証は不要
+- `UnsafeCell` により `&mut` アクセスが可能。`static mut` を直接使わないことで Rust 2024 edition の `static_mut_refs` lint に準拠
+- `get_state()` は遅延初期化パターン: 初回アクセス時に `ProcessState::new()` を生成
+
+**ao_cwao/ との違い:**
+- ao_cwao/ では毎メッセージで `db_read`/`db_write` による明示的な状態ロード/保存が必要だった
+- ao/ では HyperBEAM がメモリスナップショットを管理するため、明示的な永続化コードは不要
+
+---
+
+## メッセージフロー
+
+### 再暗号化フロー (Owner → Holder → cFrag 生成)
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant O as Owner Process
+    participant H as Holder Process
+    participant R as Requester
+
+    Note over C,O: Phase 1: kFrag 配布
+    C->>O: DelegateKFrag(kfrag_id, kfrag_bytes, holder_process_id)
+    O->>O: owner_kfrags に保存, kfrag_holders にマッピング登録
+    O->>H: OutgoingMessage: SubmitKFrag(kfrag_id, kfrag_bytes)
+    H->>H: bincode::deserialize で検証後、owner_kfrags に保存
+
+    Note over C,O: Phase 2: Capsule 配布 & 再暗号化
+    C->>O: DelegateCapsule(kfrag_id, capsule_id, capsule_bytes)
+    O->>O: kfrag_holders から Holder を検索
+    O->>H: OutgoingMessage: SubmitCapsule(kfrag_id, capsule_id, capsule_bytes)
+    H->>H: perform_reencryption(kfrag, capsule)
+    Note over H: kFrag 検証 → Umbral re-encrypt → cFrag 生成
+    H->>H: holder_cfrags に cFrag を保存
+
+    Note over R,H: Phase 3: cFrag 取得
+    R->>H: GetCFrag(kfrag_id, capsule_id)
+    H-->>R: { cfrag: [...] }
+```
+
+### Combined モード (単一プロセス)
+
+Combined モードでは、Owner と Holder が同一プロセスのため `OutgoingMessage` による転送が不要。
+クライアントが直接 `SubmitKFrag` → `SubmitCapsule` → `Reencrypt` → `GetCFrag` を順次呼び出す。
+
+---
+
+## ハンドラー API 一覧
+
+### Execute アクション
+
+| アクション | ロール | 必須フィールド | レスポンス | 説明 |
+|------------|--------|----------------|------------|------|
+| `Init` | (未初期化) | `role`: string, `from`: string | `{ initialized, role }` | プロセス初期化。ロール設定と owner_id 登録 |
+| `DelegateKFrag` | Owner/Combined | `kfrag_id`, `kfrag`: byte[], `holder_process_id` | `{ kfrag_id, delegated }` + OutgoingMessage | kFrag を保存し Holder に SubmitKFrag を送信 |
+| `DelegateCapsule` | Owner/Combined | `kfrag_id`, `capsule_id`, `capsule`: byte[] | `{ capsule_id, delegated }` + OutgoingMessage | Capsule を保存し Holder に SubmitCapsule を送信 |
+| `SubmitKFrag` | Holder/Combined | `kfrag_id`, `kfrag`: byte[] | `{ kfrag_id, stored }` | kFrag を bincode 検証後に保存（冪等） |
+| `SubmitCapsule` | Holder/Combined | `kfrag_id`, `capsule_id`, `capsule`: byte[] | `{ capsule_id, cfrag_ready }` | Capsule 受領 → 即座に再暗号化を実行 |
+| `Reencrypt` | Holder/Combined | `kfrag_id`, `capsule_id` | `{ capsule_id, cfrag_ready }` | 既存 Capsule の再暗号化を再試行 |
+
+### Query アクション
+
+| アクション | ロール | 必須フィールド | レスポンス | 説明 |
+|------------|--------|----------------|------------|------|
+| `GetCFrag` | 全ロール | `kfrag_id`, `capsule_id` | `{ kfrag_id, capsule_id, cfrag }` | 生成済み cFrag を取得 |
+| `ListCapsules` | 全ロール | `kfrag_id` | `{ kfrag_id, capsule_ids }` | 指定 kFrag に紐づく Capsule ID 一覧 |
+
+### メッセージ形式
+
+```json
+// Request (AOMessage)
+{
+  "action": "DelegateKFrag",
+  "from": "owner-wallet-address",
+  "id": "msg-001",
+  "data": {
+    "kfrag_id": "secret-1_0",
+    "kfrag": [1, 2, 3, ...],
+    "holder_process_id": "holder-process-xyz"
+  }
+}
+
+// Response (AOResponse)
+{
+  "ok": true,
+  "data": { "kfrag_id": "secret-1_0", "delegated": true },
+  "messages": [{
+    "target": "holder-process-xyz",
+    "action": "SubmitKFrag",
+    "data": { "kfrag_id": "secret-1_0", "kfrag": [1, 2, 3, ...] }
+  }]
+}
+```
+
+---
+
+## セキュリティ
+
+### 認可モデル
+
+- `Init` メッセージの `from` フィールドが `owner_id` として登録される
+- 以降の Execute アクション（Query を除く）は `from == owner_id` を検証
+- 不一致の場合は `"Unauthorized"` エラーで即拒否
+
+### 秘密鍵メモリ管理
+
+| 型 | Zeroize | ZeroizeOnDrop | 用途 |
+|----|---------|---------------|------|
+| `StoredKeyFrag` | Yes | Yes | kFrag の中間デシリアライズ。使用後にメモリクリア |
+| `StoredCFrag` | Yes | Yes | cFrag の中間デシリアライズ。使用後にメモリクリア |
+
+WASM リニアメモリ上の鍵素材は `Zeroize` + `ZeroizeOnDrop` により、変数のスコープ終了時に自動的にゼロ化される。
+
+### kFrag 検証 (PRD §6.1)
+
+再暗号化 (`perform_reencryption`) 実行前に以下を検証:
+
+1. `StoredKeyFrag` の bincode デシリアライズが成功すること
+2. `key_data` / `verification_data` が空でないこと
+3. `VerificationData` から公開鍵 (`verifying_pk`, `delegating_pk`, `receiving_pk`) をデシリアライズ
+4. `umbral_pre::KeyFrag::verify()` による暗号学的検証が成功すること
+
+検証に失敗した kFrag による再暗号化は拒否され、改竄検知として機能する。
+
+---
 
 ## ビルド
 
@@ -50,10 +240,19 @@ npm install
 node scripts/deploy.js --wallet /path/to/wallet.json
 ```
 
-## ⚠️ 残課題 (TODO)
+---
+
+## 残課題 (TODO)
 
 1. **WASM ABI検証**: HyperBEAMのbeamrが `handle(ptr, len)` を呼ぶ正確な方法をPoC検証
+   - [実装済み] `handle`, `alloc`, `dealloc`, `response_len` のエクスポートは完了
+   - [未検証] HyperBEAM 実環境での動作確認が必要
 2. **wasm32 vs wasm64**: `~wasm64@1.0`がMemory-64要求の場合 `wasm64-unknown-unknown` ターゲットが必要（experimental）
+   - [pending] HyperBEAM の実際のターゲット要件を確認中
 3. **SubMsg → async messaging**: `OutgoingMessage` の HyperBEAM ルーティング検証
+   - [実装済み] `AOResponse.messages` に `OutgoingMessage` を格納する仕組みは完了
+   - [未検証] HyperBEAM が `messages` 配列を実際にルーティングするか要確認
 4. **getrandom entropy**: 決定論的な placeholder → 本番用エントロピー注入に変更
+   - [pending] 現在は `(i * 7 + 42) % 256` の決定論的値。本番ではメッセージコンテキスト or ブロックハッシュからのエントロピー注入が必要
 5. **テスト**: `cw-multi-test` の代替テスト基盤構築
+   - [pending] クライアント側の MockAOClient による間接テストは存在。コントラクト単体のユニットテスト基盤は未構築

--- a/ao/contracts/Cargo.toml
+++ b/ao/contracts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "formix-ao-contract"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "FORMIX AO-native WASM contract for HyperBEAM"
 
 [lib]

--- a/ao/contracts/src/getrandom_impl.rs
+++ b/ao/contracts/src/getrandom_impl.rs
@@ -1,18 +1,11 @@
-/// Custom getrandom implementation for WASM environment.
-///
-/// AO processes don't have access to OS-level randomness.
-/// For proxy re-encryption (umbral-pre), randomness is needed for kFrag generation.
-/// In production, entropy should be injected via message parameters.
-///
-/// TODO: Replace with a proper entropy injection mechanism.
-///   Option 1: Accept entropy as a message field (client provides random bytes)
-///   Option 2: Use AO's block hash as entropy seed
-///   Option 3: Use a PRNG seeded from process ID + message ID
+// AO processes lack OS-level randomness. This placeholder satisfies the
+// getrandom trait so umbral-pre compiles, but it is NOT cryptographically
+// secure. Production must inject real entropy (message field, block hash,
+// or PRNG seeded from process ID + message ID).
 getrandom::register_custom_getrandom!(ao_getrandom);
 
 pub fn ao_getrandom(buf: &mut [u8]) -> Result<(), getrandom::Error> {
-    // Deterministic placeholder - NOT cryptographically secure
-    // TODO: Replace with entropy from message context
+    // TODO: replace with entropy from message context
     for (i, byte) in buf.iter_mut().enumerate() {
         *byte = (i as u8).wrapping_mul(7).wrapping_add(42);
     }

--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -30,13 +30,22 @@ pub fn dispatch(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
     let role = state.role.as_ref().unwrap();
 
     // PRD §4: role-based action routing via process tag / msg.role
+    // Combined role allows all Owner + Holder actions (single-process setups).
     match (role, msg.action.as_str()) {
-        (ProcessRole::Owner, "DelegateKFrag") => handle_delegate_kfrag(state, msg),
-        (ProcessRole::Owner, "DelegateCapsule") => handle_delegate_capsule(state, msg),
+        (ProcessRole::Owner | ProcessRole::Combined, "DelegateKFrag") => {
+            handle_delegate_kfrag(state, msg)
+        }
+        (ProcessRole::Owner | ProcessRole::Combined, "DelegateCapsule") => {
+            handle_delegate_capsule(state, msg)
+        }
 
-        (ProcessRole::Holder, "SubmitKFrag") => handle_submit_kfrag(state, msg),
-        (ProcessRole::Holder, "SubmitCapsule") => handle_submit_capsule(state, msg),
-        (ProcessRole::Holder, "Reencrypt") => handle_reencrypt(state, msg),
+        (ProcessRole::Holder | ProcessRole::Combined, "SubmitKFrag") => {
+            handle_submit_kfrag(state, msg)
+        }
+        (ProcessRole::Holder | ProcessRole::Combined, "SubmitCapsule") => {
+            handle_submit_capsule(state, msg)
+        }
+        (ProcessRole::Holder | ProcessRole::Combined, "Reencrypt") => handle_reencrypt(state, msg),
 
         // Queries — allowed for any initialized role
         (_, "GetCFrag") => handle_get_cfrag(state, msg),
@@ -73,6 +82,7 @@ fn handle_init(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
         "Owner" => ProcessRole::Owner,
         "Holder" => ProcessRole::Holder,
         "Requester" => ProcessRole::Requester,
+        "Combined" => ProcessRole::Combined,
         other => return AOResponse::error(format!("Invalid role: {other}")),
     };
 

--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -7,6 +7,17 @@ use crate::state::{
     VerificationData,
 };
 
+fn parse_byte_array(arr: &[serde_json::Value]) -> Result<Vec<u8>, &'static str> {
+    arr.iter()
+        .map(|v| {
+            v.as_u64()
+                .filter(|&n| n <= 255)
+                .map(|n| n as u8)
+                .ok_or("Byte array contains invalid value (expected 0-255)")
+        })
+        .collect()
+}
+
 pub fn dispatch(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
     if msg.action == "Init" {
         return handle_init(state, msg);
@@ -87,11 +98,10 @@ fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse
         None => return AOResponse::error("Missing kfrag_id"),
     };
     let kfrag_bytes = match data["kfrag"].as_array() {
-        Some(arr) => arr
-            .iter()
-            .filter_map(|v| v.as_u64())
-            .map(|n| n as u8)
-            .collect::<Vec<_>>(),
+        Some(arr) => match parse_byte_array(arr) {
+            Ok(bytes) => bytes,
+            Err(e) => return AOResponse::error(e),
+        },
         None => return AOResponse::error("Missing or invalid kfrag bytes"),
     };
     let holder_process_id = match data["holder_process_id"].as_str() {
@@ -141,11 +151,10 @@ fn handle_delegate_capsule(state: &mut ProcessState, msg: AOMessage) -> AORespon
         None => return AOResponse::error("Missing capsule_id"),
     };
     let capsule_bytes = match data["capsule"].as_array() {
-        Some(arr) => arr
-            .iter()
-            .filter_map(|v| v.as_u64())
-            .map(|n| n as u8)
-            .collect::<Vec<_>>(),
+        Some(arr) => match parse_byte_array(arr) {
+            Ok(bytes) => bytes,
+            Err(e) => return AOResponse::error(e),
+        },
         None => return AOResponse::error("Missing capsule bytes"),
     };
 
@@ -323,7 +332,12 @@ fn handle_reencrypt(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
             }
             AOResponse::success(json!({ "capsule_id": capsule_id, "cfrag_ready": true }))
         }
-        Err(e) => AOResponse::error(format!("Reencryption retry failed: {e}")),
+        Err(e) => {
+            if let Some(cap) = state.owner_capsules.get_mut(&cap_key) {
+                cap.status = CapsuleStatus::Error(e.clone());
+            }
+            AOResponse::error(format!("Reencryption retry failed: {e}"))
+        }
     }
 }
 

--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -265,6 +265,12 @@ fn handle_submit_capsule(state: &mut ProcessState, msg: AOMessage) -> AOResponse
         },
     );
 
+    state
+        .kfrag_to_caps
+        .entry(kfrag_id.clone())
+        .or_default()
+        .push(capsule_id.clone());
+
     match perform_reencryption(state, &kfrag_id, &capsule_bytes) {
         Ok(cfrag_bytes) => {
             state.holder_cfrags.insert(cap_key.clone(), cfrag_bytes);

--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -1,46 +1,94 @@
-/// Business logic handlers - AO-native port of ao_cwao/contracts/src/handlers.rs
-///
-/// Key changes from CosmWasm version:
-/// - deps.storage replaced by &mut ProcessState
-/// - SubMsg replaced by OutgoingMessage (async AO messages)
-/// - Response::new() replaced by AOResponse::success/error
-/// - umbral-pre logic: UNCHANGED
-
-use umbral_pre::{self, DefaultDeserialize, DefaultSerialize};
 use serde_json::json;
+use umbral_pre::{self, DefaultDeserialize, DefaultSerialize};
 
 use crate::message::{AOMessage, AOResponse, OutgoingMessage};
-use crate::state::{CapsuleStatus, OwnerCapsuleData, ProcessState};
+use crate::state::{
+    CapsuleStatus, OwnerCapsuleData, ProcessRole, ProcessState, StoredCFrag, StoredKeyFrag,
+    VerificationData,
+};
 
 pub fn dispatch(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    match msg.action.as_str() {
-        "DelegateKFrag"    => handle_delegate_kfrag(state, msg),
-        "DelegateCapsule"  => handle_delegate_capsule(state, msg),
-        "SubmitKFrag"      => handle_submit_kfrag(state, msg),
-        "SubmitCapsule"    => handle_submit_capsule(state, msg),
-        "Reencrypt"        => handle_reencrypt(state, msg),
-        "GetCFrag"         => handle_get_cfrag(state, msg),
-        "ListCapsules"     => handle_list_capsules(state, msg),
-        action             => AOResponse::error(format!("Unknown action: {action}")),
+    if msg.action == "Init" {
+        return handle_init(state, msg);
+    }
+
+    if !state.is_initialized() {
+        return AOResponse::error("Process not initialized — send Init first");
+    }
+
+    let role = state.role.as_ref().unwrap();
+
+    // PRD §4: role-based action routing via process tag / msg.role
+    match (role, msg.action.as_str()) {
+        (ProcessRole::Owner, "DelegateKFrag") => handle_delegate_kfrag(state, msg),
+        (ProcessRole::Owner, "DelegateCapsule") => handle_delegate_capsule(state, msg),
+
+        (ProcessRole::Holder, "SubmitKFrag") => handle_submit_kfrag(state, msg),
+        (ProcessRole::Holder, "SubmitCapsule") => handle_submit_capsule(state, msg),
+        (ProcessRole::Holder, "Reencrypt") => handle_reencrypt(state, msg),
+
+        // Queries — allowed for any initialized role
+        (_, "GetCFrag") => handle_get_cfrag(state, msg),
+        (_, "ListCapsules") => handle_list_capsules(state, msg),
+
+        (role, action) => {
+            AOResponse::error(format!("Action '{action}' not permitted for role {role:?}"))
+        }
     }
 }
 
-// ─── DelegateKFrag ─────────────────────────────────────────────────────────────
-// Owner sends kFrag + holder target to this contract.
-// Previously used SubMsg to call SubmitKFrag on a separate holder contract.
-// AO version: record the delegation, emit OutgoingMessage to holder.
-fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+// ─── Init ──────────────────────────────────────────────────────────────────────
+fn handle_init(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+    if state.is_initialized() {
+        return AOResponse::error("Already initialized");
+    }
+
+    let sender = match &msg.from {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => return AOResponse::error("Init requires a valid sender (from field)"),
+    };
+
     let data = match msg.data {
         Some(d) => d,
-        None    => return AOResponse::error("Missing data"),
+        None => return AOResponse::error("Missing data"),
+    };
+
+    let role_str = match data["role"].as_str() {
+        Some(s) => s,
+        None => return AOResponse::error("Missing role"),
+    };
+
+    let role = match role_str {
+        "Owner" => ProcessRole::Owner,
+        "Holder" => ProcessRole::Holder,
+        "Requester" => ProcessRole::Requester,
+        other => return AOResponse::error(format!("Invalid role: {other}")),
+    };
+
+    state.role = Some(role.clone());
+    state.owner_id = Some(sender);
+
+    AOResponse::success(json!({ "initialized": true, "role": role_str }))
+}
+
+// ─── DelegateKFrag ─────────────────────────────────────────────────────────────
+fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+    if !state.is_authorized_sender(msg.from.as_deref()) {
+        return AOResponse::error("Unauthorized: only the owner can delegate kFrags");
+    }
+
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
     };
 
     let kfrag_id = match data["kfrag_id"].as_str() {
         Some(s) => s.to_string(),
-        None    => return AOResponse::error("Missing kfrag_id"),
+        None => return AOResponse::error("Missing kfrag_id"),
     };
     let kfrag_bytes = match data["kfrag"].as_array() {
-        Some(arr) => arr.iter()
+        Some(arr) => arr
+            .iter()
             .filter_map(|v| v.as_u64())
             .map(|n| n as u8)
             .collect::<Vec<_>>(),
@@ -48,14 +96,16 @@ fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse
     };
     let holder_process_id = match data["holder_process_id"].as_str() {
         Some(s) => s.to_string(),
-        None    => return AOResponse::error("Missing holder_process_id"),
+        None => return AOResponse::error("Missing holder_process_id"),
     };
 
-    // Store the kfrag and holder mapping
-    state.owner_kfrags.insert(kfrag_id.clone(), kfrag_bytes.clone());
-    state.kfrag_holders.insert(kfrag_id.clone(), holder_process_id.clone());
+    state
+        .owner_kfrags
+        .insert(kfrag_id.clone(), kfrag_bytes.clone());
+    state
+        .kfrag_holders
+        .insert(kfrag_id.clone(), holder_process_id.clone());
 
-    // Emit message to holder (replaces SubMsg)
     let outgoing = OutgoingMessage {
         target: holder_process_id,
         action: "SubmitKFrag".to_string(),
@@ -73,45 +123,54 @@ fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse
 
 // ─── DelegateCapsule ──────────────────────────────────────────────────────────
 fn handle_delegate_capsule(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+    if !state.is_authorized_sender(msg.from.as_deref()) {
+        return AOResponse::error("Unauthorized: only the owner can delegate capsules");
+    }
+
     let data = match msg.data {
         Some(d) => d,
-        None    => return AOResponse::error("Missing data"),
+        None => return AOResponse::error("Missing data"),
     };
 
     let kfrag_id = match data["kfrag_id"].as_str() {
         Some(s) => s.to_string(),
-        None    => return AOResponse::error("Missing kfrag_id"),
+        None => return AOResponse::error("Missing kfrag_id"),
     };
     let capsule_id = match data["capsule_id"].as_str() {
         Some(s) => s.to_string(),
-        None    => return AOResponse::error("Missing capsule_id"),
+        None => return AOResponse::error("Missing capsule_id"),
     };
     let capsule_bytes = match data["capsule"].as_array() {
-        Some(arr) => arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect::<Vec<_>>(),
-        None      => return AOResponse::error("Missing capsule bytes"),
+        Some(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_u64())
+            .map(|n| n as u8)
+            .collect::<Vec<_>>(),
+        None => return AOResponse::error("Missing capsule bytes"),
     };
 
     let holder = match state.kfrag_holders.get(&kfrag_id) {
         Some(h) => h.clone(),
-        None    => return AOResponse::error(format!("No holder registered for kfrag_id: {kfrag_id}")),
+        None => return AOResponse::error(format!("No holder registered for kfrag_id: {kfrag_id}")),
     };
 
-    // Store capsule locally
     let cap_key = ProcessState::cap_key(&kfrag_id, &capsule_id);
-    state.owner_capsules.insert(cap_key.clone(), OwnerCapsuleData {
-        capsule_bytes: capsule_bytes.clone(),
-        status: CapsuleStatus::Received,
-        kfrag_id: kfrag_id.clone(),
-        capsule_id: capsule_id.clone(),
-    });
+    state.owner_capsules.insert(
+        cap_key.clone(),
+        OwnerCapsuleData {
+            capsule_bytes: capsule_bytes.clone(),
+            status: CapsuleStatus::Received,
+            kfrag_id: kfrag_id.clone(),
+            capsule_id: capsule_id.clone(),
+        },
+    );
 
-    // Track for listing
-    state.kfrag_to_caps
+    state
+        .kfrag_to_caps
         .entry(kfrag_id.clone())
         .or_default()
         .push(capsule_id.clone());
 
-    // Emit message to holder
     let outgoing = OutgoingMessage {
         target: holder,
         action: "SubmitCapsule".to_string(),
@@ -129,18 +188,32 @@ fn handle_delegate_capsule(state: &mut ProcessState, msg: AOMessage) -> AORespon
 }
 
 // ─── SubmitKFrag ──────────────────────────────────────────────────────────────
-// Holder stores kFrag. Called via AO message (async, was SubMsg before).
 fn handle_submit_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    let data = match msg.data { Some(d) => d, None => return AOResponse::error("Missing data") };
-    let kfrag_id = match data["kfrag_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing kfrag_id") };
+    if !state.is_authorized_sender(msg.from.as_deref()) {
+        return AOResponse::error("Unauthorized: only the registered owner can submit kFrags");
+    }
+
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let kfrag_id = match data["kfrag_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing kfrag_id"),
+    };
     let kfrag_bytes: Vec<u8> = match data["kfrag"].as_array() {
-        Some(arr) => arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect(),
-        None      => return AOResponse::error("Missing kfrag"),
+        Some(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_u64())
+            .map(|n| n as u8)
+            .collect(),
+        None => return AOResponse::error("Missing kfrag"),
     };
 
-    // Idempotent: if already stored, no-op
     if state.owner_kfrags.contains_key(&kfrag_id) {
-        return AOResponse::success(json!({ "kfrag_id": kfrag_id, "stored": true, "idempotent": true }));
+        return AOResponse::success(json!({
+            "kfrag_id": kfrag_id, "stored": true, "idempotent": true
+        }));
     }
 
     state.owner_kfrags.insert(kfrag_id.clone(), kfrag_bytes);
@@ -148,32 +221,50 @@ fn handle_submit_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
 }
 
 // ─── SubmitCapsule ────────────────────────────────────────────────────────────
-// Holder stores capsule and performs re-encryption.
 fn handle_submit_capsule(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    let data = match msg.data { Some(d) => d, None => return AOResponse::error("Missing data") };
-    let kfrag_id = match data["kfrag_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing kfrag_id") };
-    let capsule_id = match data["capsule_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing capsule_id") };
+    if !state.is_authorized_sender(msg.from.as_deref()) {
+        return AOResponse::error("Unauthorized: only the registered owner can submit capsules");
+    }
+
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let kfrag_id = match data["kfrag_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing kfrag_id"),
+    };
+    let capsule_id = match data["capsule_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing capsule_id"),
+    };
     let capsule_bytes: Vec<u8> = match data["capsule"].as_array() {
-        Some(arr) => arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect(),
-        None      => return AOResponse::error("Missing capsule"),
+        Some(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_u64())
+            .map(|n| n as u8)
+            .collect(),
+        None => return AOResponse::error("Missing capsule"),
     };
 
     let cap_key = ProcessState::cap_key(&kfrag_id, &capsule_id);
 
-    // Idempotency check
     if state.holder_cfrags.contains_key(&cap_key) {
-        return AOResponse::success(json!({ "capsule_id": capsule_id, "idempotent": true }));
+        return AOResponse::success(json!({
+            "capsule_id": capsule_id, "idempotent": true
+        }));
     }
 
-    // Store capsule
-    state.owner_capsules.insert(cap_key.clone(), OwnerCapsuleData {
-        capsule_bytes: capsule_bytes.clone(),
-        status: CapsuleStatus::ReencInProgress,
-        kfrag_id: kfrag_id.clone(),
-        capsule_id: capsule_id.clone(),
-    });
+    state.owner_capsules.insert(
+        cap_key.clone(),
+        OwnerCapsuleData {
+            capsule_bytes: capsule_bytes.clone(),
+            status: CapsuleStatus::ReencInProgress,
+            kfrag_id: kfrag_id.clone(),
+            capsule_id: capsule_id.clone(),
+        },
+    );
 
-    // Perform re-encryption (same logic as ao_cwao/handlers.rs)
     match perform_reencryption(state, &kfrag_id, &capsule_bytes) {
         Ok(cfrag_bytes) => {
             state.holder_cfrags.insert(cap_key.clone(), cfrag_bytes);
@@ -193,9 +284,24 @@ fn handle_submit_capsule(state: &mut ProcessState, msg: AOMessage) -> AOResponse
 
 // ─── Reencrypt (retry) ────────────────────────────────────────────────────────
 fn handle_reencrypt(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    let data = match msg.data { Some(d) => d, None => return AOResponse::error("Missing data") };
-    let kfrag_id = match data["kfrag_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing kfrag_id") };
-    let capsule_id = match data["capsule_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing capsule_id") };
+    if !state.is_authorized_sender(msg.from.as_deref()) {
+        return AOResponse::error(
+            "Unauthorized: only the registered owner can trigger reencryption",
+        );
+    }
+
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let kfrag_id = match data["kfrag_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing kfrag_id"),
+    };
+    let capsule_id = match data["capsule_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing capsule_id"),
+    };
     let cap_key = ProcessState::cap_key(&kfrag_id, &capsule_id);
 
     let capsule_bytes = match state.owner_capsules.get(&cap_key) {
@@ -217,9 +323,18 @@ fn handle_reencrypt(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
 
 // ─── GetCFrag (query) ─────────────────────────────────────────────────────────
 fn handle_get_cfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    let data = match msg.data { Some(d) => d, None => return AOResponse::error("Missing data") };
-    let kfrag_id = match data["kfrag_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing kfrag_id") };
-    let capsule_id = match data["capsule_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing capsule_id") };
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let kfrag_id = match data["kfrag_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing kfrag_id"),
+    };
+    let capsule_id = match data["capsule_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing capsule_id"),
+    };
     let cap_key = ProcessState::cap_key(&kfrag_id, &capsule_id);
 
     match state.holder_cfrags.get(&cap_key) {
@@ -234,56 +349,83 @@ fn handle_get_cfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
 
 // ─── ListCapsules ─────────────────────────────────────────────────────────────
 fn handle_list_capsules(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
-    let data = match msg.data { Some(d) => d, None => return AOResponse::error("Missing data") };
-    let kfrag_id = match data["kfrag_id"].as_str() { Some(s) => s.to_string(), None => return AOResponse::error("Missing kfrag_id") };
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let kfrag_id = match data["kfrag_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing kfrag_id"),
+    };
 
-    let capsule_ids = state.kfrag_to_caps.get(&kfrag_id).cloned().unwrap_or_default();
+    let capsule_ids = state
+        .kfrag_to_caps
+        .get(&kfrag_id)
+        .cloned()
+        .unwrap_or_default();
     AOResponse::success(json!({ "kfrag_id": kfrag_id, "capsule_ids": capsule_ids }))
 }
 
-// ─── Core re-encryption logic (UNCHANGED from ao_cwao/handlers.rs) ────────────
-fn perform_reencryption(state: &ProcessState, kfrag_id: &str, capsule_bytes: &[u8])
-    -> Result<Vec<u8>, String>
-{
-    use umbral_pre::{KeyFrag, Capsule};
-
-    // Deserialize kFrag
-    let kfrag_bytes = state.owner_kfrags.get(kfrag_id)
+// ─── Core re-encryption (ported from ao_cwao/ with kFrag verification) ────────
+fn perform_reencryption(
+    state: &ProcessState,
+    kfrag_id: &str,
+    capsule_bytes: &[u8],
+) -> Result<Vec<u8>, String> {
+    let kfrag_bytes = state
+        .owner_kfrags
+        .get(kfrag_id)
         .ok_or_else(|| format!("KFrag not found: {kfrag_id}"))?;
 
-    // bincode → StoredKeyFrag (same as ao_cwao/)
-    let stored_kfrag: StoredKeyFrag = bincode::deserialize(kfrag_bytes)
-        .map_err(|e| format!("KFrag deserialize failed: {e}"))?;
+    if kfrag_bytes.is_empty() {
+        return Err("Empty kFrag payload".to_string());
+    }
+    if capsule_bytes.is_empty() {
+        return Err("Empty capsule payload".to_string());
+    }
 
-    // Deserialize capsule
-    let capsule = Capsule::from_bytes(capsule_bytes)
+    let stored_kfrag: StoredKeyFrag =
+        bincode::deserialize(kfrag_bytes).map_err(|e| format!("KFrag deserialize failed: {e}"))?;
+
+    if stored_kfrag.key_data.is_empty() {
+        return Err("Invalid kFrag data".to_string());
+    }
+    if stored_kfrag.verification_data.is_empty() {
+        return Err("Missing verification data".to_string());
+    }
+
+    // Cryptographic verification: deserialize public keys from verification_data
+    // and verify the kFrag before re-encrypting (PRD §6.1 tamper detection)
+    let verification: VerificationData = bincode::deserialize(&stored_kfrag.verification_data)
+        .map_err(|_| "Invalid verification payload".to_string())?;
+
+    let verifying_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.verifying_pk)
+        .map_err(|_| "Invalid verifying key".to_string())?;
+
+    let delegating_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.delegating_pk)
+        .map_err(|_| "Invalid delegating key".to_string())?;
+
+    let receiving_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.receiving_pk)
+        .map_err(|_| "Invalid receiving key".to_string())?;
+
+    let key_frag = umbral_pre::KeyFrag::from_bytes(&stored_kfrag.key_data)
+        .map_err(|_| "Failed to deserialize kFrag".to_string())?;
+
+    let verified_kfrag = key_frag
+        .verify(&verifying_pk, Some(&delegating_pk), Some(&receiving_pk))
+        .map_err(|_| "kFrag verification failed".to_string())?;
+
+    let capsule = umbral_pre::Capsule::from_bytes(capsule_bytes)
         .map_err(|e| format!("Capsule deserialize failed: {e:?}"))?;
 
-    // Reconstruct kFrag for umbral-pre
-    let kfrag = KeyFrag::from_bytes(&stored_kfrag.key_data)
-        .map_err(|e| format!("KeyFrag from bytes failed: {e:?}"))?;
+    let verified_cfrag = umbral_pre::reencrypt(&capsule, verified_kfrag);
+    let cfrag = verified_cfrag.unverify();
+    let cfrag_bytes = cfrag
+        .to_bytes()
+        .map_err(|_| "Failed to serialize cFrag".to_string())?;
 
-    // Perform re-encryption
-    let cfrag = umbral_pre::reencrypt(&capsule, &kfrag, None);
-
-    // Serialize cFrag
     let stored_cfrag = StoredCFrag {
-        fragment_data: cfrag.to_bytes().to_vec(),
+        fragment_data: cfrag_bytes.to_vec(),
     };
-    bincode::serialize(&stored_cfrag)
-        .map_err(|e| format!("CFrag serialize failed: {e}"))
-}
-
-// ─── Serialized crypto types (mirrors ao_cwao/state.rs) ──────────────────────
-#[derive(serde::Serialize, serde::Deserialize)]
-struct StoredKeyFrag {
-    pub id: String,
-    pub key_data: Vec<u8>,
-    pub verification_data: Vec<u8>,
-    pub precursor: Vec<u8>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct StoredCFrag {
-    pub fragment_data: Vec<u8>,
+    bincode::serialize(&stored_cfrag).map_err(|e| format!("CFrag serialize failed: {e}"))
 }

--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -211,13 +211,17 @@ fn handle_submit_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
         None => return AOResponse::error("Missing kfrag_id"),
     };
     let kfrag_bytes: Vec<u8> = match data["kfrag"].as_array() {
-        Some(arr) => arr
-            .iter()
-            .filter_map(|v| v.as_u64())
-            .map(|n| n as u8)
-            .collect(),
+        Some(arr) => match parse_byte_array(arr) {
+            Ok(bytes) => bytes,
+            Err(e) => return AOResponse::error(e),
+        },
         None => return AOResponse::error("Missing kfrag"),
     };
+
+    // Validate kFrag is deserializable before persisting to prevent bricked state
+    if let Err(e) = bincode::deserialize::<StoredKeyFrag>(&kfrag_bytes) {
+        return AOResponse::error(format!("Invalid kFrag payload: {e}"));
+    }
 
     if state.owner_kfrags.contains_key(&kfrag_id) {
         return AOResponse::success(json!({
@@ -248,11 +252,10 @@ fn handle_submit_capsule(state: &mut ProcessState, msg: AOMessage) -> AOResponse
         None => return AOResponse::error("Missing capsule_id"),
     };
     let capsule_bytes: Vec<u8> = match data["capsule"].as_array() {
-        Some(arr) => arr
-            .iter()
-            .filter_map(|v| v.as_u64())
-            .map(|n| n as u8)
-            .collect(),
+        Some(arr) => match parse_byte_array(arr) {
+            Ok(bytes) => bytes,
+            Err(e) => return AOResponse::error(e),
+        },
         None => return AOResponse::error("Missing capsule"),
     };
 

--- a/ao/contracts/src/lib.rs
+++ b/ao/contracts/src/lib.rs
@@ -1,67 +1,48 @@
 /// FORMIX AO-native WASM Contract for HyperBEAM (~wasm64@1.0)
 ///
-/// Architecture:
-/// - State is managed as global Rust statics, persisted via WASM memory snapshots.
-///   HyperBEAM serializes/deserializes the entire WASM memory between message calls.
-/// - Entry point: `handle(msg_ptr: i32, msg_len: i32) -> i32`
-///   HyperBEAM writes the message JSON to WASM memory, calls handle with ptr+len.
-///   handle returns a pointer to the JSON-encoded result.
-/// - No CosmWasm host functions. No db_read/db_write. Pure WASM.
-///
-/// Migration from ao_cwao/:
-/// - cosmwasm_std / cw-storage-plus / cw-multi-test → removed
-/// - instantiate/execute/query/reply → single `handle` function
-/// - MAP.save(deps.storage, key, &data) → PROCESS_STATE.insert(key, data)
-/// - SubMsg (cross-contract) → ao_send import (async AO message)
-/// - umbral-pre logic: unchanged
-/// - getrandom custom impl: unchanged
-
-use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
-use umbral_pre;
-
+/// State lives in global Rust statics. HyperBEAM snapshots/restores the
+/// entire WASM linear memory between messages, so globals survive across
+/// invocations — unlike CWAO where state had to be read/written via
+/// db_read/db_write on each message.
 mod getrandom_impl;
+mod handlers;
 mod message;
 mod state;
-mod handlers;
+
+use std::cell::UnsafeCell;
 
 use message::{AOMessage, AOResponse};
 use state::ProcessState;
 
 // ─── Global State ──────────────────────────────────────────────────────────────
-//
-// In AO's execution model, WASM memory is serialized (snapshot) after each
-// message and deserialized (restore) before the next. This means global statics
-// survive across invocations as long as HyperBEAM manages the snapshot.
-//
-// TODO: Replace with a proper global once mutex requirements are clear for WASM
-// (WASM is single-threaded, so static mut is safe here)
-static mut PROCESS_STATE: Option<ProcessState> = None;
+// Safety: WASM is single-threaded; no concurrent access possible.
+// UnsafeCell + manual Sync avoids Rust 2024's static_mut_refs prohibition.
+struct SyncCell<T>(UnsafeCell<T>);
+unsafe impl<T> Sync for SyncCell<T> {}
+
+static PROCESS_STATE: SyncCell<Option<ProcessState>> = SyncCell(UnsafeCell::new(None));
+static RESPONSE_BUF: SyncCell<Vec<u8>> = SyncCell(UnsafeCell::new(Vec::new()));
 
 fn get_state() -> &'static mut ProcessState {
-    // Safety: WASM is single-threaded
     unsafe {
-        if PROCESS_STATE.is_none() {
-            PROCESS_STATE = Some(ProcessState::new());
+        let state = &mut *PROCESS_STATE.0.get();
+        if state.is_none() {
+            *state = Some(ProcessState::new());
         }
-        PROCESS_STATE.as_mut().unwrap()
+        state.as_mut().unwrap()
     }
 }
 
 // ─── WASM Entry Point ──────────────────────────────────────────────────────────
-//
-// HyperBEAM dev_wasm calls this function via:
-//   hb_beamr:call(Instance, "handle", [msg_ptr, msg_len], ...)
-//
-// Parameters are passed as WASM i32 values pointing into WASM linear memory.
-// The host writes the message JSON to WASM memory before calling.
-// The return value is a pointer to the JSON-encoded response in WASM memory.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn handle(msg_ptr: i32, msg_len: i32) -> i32 {
-    let msg_bytes = unsafe {
-        std::slice::from_raw_parts(msg_ptr as *const u8, msg_len as usize)
-    };
+    if msg_len <= 0 {
+        let response = AOResponse::error("Invalid message length");
+        let response_json = serde_json::to_vec(&response).unwrap_or_else(|_| b"{}".to_vec());
+        return write_response(response_json);
+    }
+
+    let msg_bytes = unsafe { core::slice::from_raw_parts(msg_ptr as *const u8, msg_len as usize) };
 
     let response = match serde_json::from_slice::<AOMessage>(msg_bytes) {
         Ok(msg) => handlers::dispatch(get_state(), msg),
@@ -69,41 +50,46 @@ pub extern "C" fn handle(msg_ptr: i32, msg_len: i32) -> i32 {
     };
 
     let response_json = serde_json::to_vec(&response).unwrap_or_else(|_| b"{}".to_vec());
-
-    // Write response to WASM memory and return pointer
-    // The host will call the `read` function to retrieve the response by pointer
     write_response(response_json)
 }
 
 // ─── Memory helpers ────────────────────────────────────────────────────────────
-//
-// Static buffer for response output.
-// NOTE: This is a placeholder implementation.
-// Real implementation needs proper allocator + length-prefix or length return.
-static mut RESPONSE_BUF: Vec<u8> = Vec::new();
-
 fn write_response(data: Vec<u8>) -> i32 {
-    // Safety: single-threaded WASM
     unsafe {
-        RESPONSE_BUF = data;
-        RESPONSE_BUF.as_ptr() as i32
+        let buf = &mut *RESPONSE_BUF.0.get();
+        *buf = data;
+        buf.as_ptr() as i32
     }
 }
 
-/// Allocator for host-side writes into WASM memory.
-/// HyperBEAM uses hb_beamr_io::write_string which writes directly to WASM memory.
-/// Exposing alloc allows the host to allocate space before writing.
-#[no_mangle]
+/// Host calls this to allocate WASM memory before writing the incoming message.
+#[unsafe(no_mangle)]
 pub extern "C" fn alloc(size: i32) -> i32 {
-    let buf = vec![0u8; size as usize];
-    let ptr = buf.as_ptr() as i32;
-    std::mem::forget(buf); // prevent deallocation
-    ptr
+    if size <= 0 {
+        return 0;
+    }
+    let layout = std::alloc::Layout::from_size_align(size as usize, 1).expect("invalid layout");
+    let ptr = unsafe { std::alloc::alloc(layout) };
+    ptr as i32
 }
 
-/// Returns the length of the last response written to RESPONSE_BUF.
-/// The host reads: ptr = handle(...), len = response_len(), then reads ptr..ptr+len.
-#[no_mangle]
+/// Host calls this to free previously allocated WASM memory.
+#[unsafe(no_mangle)]
+pub extern "C" fn dealloc(ptr: i32, size: i32) {
+    if ptr == 0 || size <= 0 {
+        return;
+    }
+    let layout = std::alloc::Layout::from_size_align(size as usize, 1).expect("invalid layout");
+    unsafe {
+        std::alloc::dealloc(ptr as *mut u8, layout);
+    }
+}
+
+/// Returns the length of the last response (so the host can read ptr..ptr+len).
+#[unsafe(no_mangle)]
 pub extern "C" fn response_len() -> i32 {
-    unsafe { RESPONSE_BUF.len() as i32 }
+    unsafe {
+        let buf = &*RESPONSE_BUF.0.get();
+        buf.len() as i32
+    }
 }

--- a/ao/contracts/src/message.rs
+++ b/ao/contracts/src/message.rs
@@ -39,14 +39,29 @@ pub struct OutgoingMessage {
 
 impl AOResponse {
     pub fn success(data: serde_json::Value) -> Self {
-        Self { ok: true, data: Some(data), error: None, messages: Vec::new() }
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+            messages: Vec::new(),
+        }
     }
 
     pub fn success_with_messages(data: serde_json::Value, messages: Vec<OutgoingMessage>) -> Self {
-        Self { ok: true, data: Some(data), error: None, messages }
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+            messages,
+        }
     }
 
     pub fn error(msg: impl Into<String>) -> Self {
-        Self { ok: false, data: None, error: Some(msg.into()), messages: Vec::new() }
+        Self {
+            ok: false,
+            data: None,
+            error: Some(msg.into()),
+            messages: Vec::new(),
+        }
     }
 }

--- a/ao/contracts/src/state.rs
+++ b/ao/contracts/src/state.rs
@@ -8,6 +8,8 @@ pub enum ProcessRole {
     Owner,
     Holder,
     Requester,
+    /// Single-process mode: allows both Owner and Holder actions.
+    Combined,
 }
 
 /// WASM-memory-resident state, persisted via HyperBEAM memory snapshots.

--- a/ao/contracts/src/state.rs
+++ b/ao/contracts/src/state.rs
@@ -1,34 +1,37 @@
 use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
 
-/// Replaces ao_cwao/'s CosmWasm storage maps.
-/// All data lives in WASM linear memory; HyperBEAM snapshots/restores it.
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProcessRole {
+    Owner,
+    Holder,
+    Requester,
+}
+
+/// WASM-memory-resident state, persisted via HyperBEAM memory snapshots.
 ///
 /// Key naming mirrors ao_cwao/:
-///   OWNER_KFRAGS     → owner_kfrags:  (kfrag_id)         → OwnerKFragData
-///   OWNER_CAPSULES   → owner_capsules: (kfrag_id, cap_id) → OwnerCapsuleData
-///   HOLDER_CFRAGS    → holder_cfrags:  (kfrag_id, cap_id) → HolderCFragData
-///   KFRAG_HOLDERS    → kfrag_holders:  kfrag_id           → holder_process_id
-///   INDEX_KFRAG_TO_CAPS → kfrag_to_caps: kfrag_id         → [capsule_ids]
+///   OWNER_KFRAGS     -> owner_kfrags:  (kfrag_id)         -> raw bytes
+///   OWNER_CAPSULES   -> owner_capsules: (kfrag_id, cap_id) -> OwnerCapsuleData
+///   HOLDER_CFRAGS    -> holder_cfrags:  (kfrag_id, cap_id) -> raw bytes
+///   KFRAG_HOLDERS    -> kfrag_holders:  kfrag_id           -> holder_process_id
+///   INDEX_KFRAG_TO_CAPS -> kfrag_to_caps: kfrag_id         -> [capsule_ids]
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ProcessState {
-    /// kfrag_id → raw kFrag bytes (bincode-encoded StoredKeyFrag)
+    pub role: Option<ProcessRole>,
+    /// Authorized owner address (the AO process/wallet that initialized this contract)
+    pub owner_id: Option<String>,
+
     pub owner_kfrags: HashMap<String, Vec<u8>>,
-
-    /// (kfrag_id, capsule_id) compound key → capsule data
     pub owner_capsules: HashMap<String, OwnerCapsuleData>,
-
-    /// (kfrag_id, capsule_id) compound key → re-encrypted cFrag bytes
     pub holder_cfrags: HashMap<String, Vec<u8>>,
-
-    /// kfrag_id → target holder AO process ID (replaces DEFAULT_HOLDER_PROCESS_ID)
     pub kfrag_holders: HashMap<String, String>,
-
-    /// kfrag_id → list of capsule_ids (for listing)
     pub kfrag_to_caps: HashMap<String, Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OwnerCapsuleData {
     pub capsule_bytes: Vec<u8>,
     pub status: CapsuleStatus,
@@ -49,8 +52,42 @@ impl ProcessState {
         Self::default()
     }
 
-    /// Compound key for capsule/cfrag lookups
     pub fn cap_key(kfrag_id: &str, capsule_id: &str) -> String {
         format!("{}/{}", kfrag_id, capsule_id)
     }
+
+    pub fn is_initialized(&self) -> bool {
+        self.role.is_some()
+    }
+
+    pub fn is_authorized_sender(&self, from: Option<&str>) -> bool {
+        match (&self.owner_id, from) {
+            (Some(owner), Some(sender)) => owner == sender,
+            _ => false,
+        }
+    }
+}
+
+/// Intermediate deserialized kFrag — zeroized on drop to prevent
+/// key material from lingering in WASM linear memory after use.
+#[derive(Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct StoredKeyFrag {
+    #[zeroize(skip)]
+    pub id: String,
+    pub key_data: Vec<u8>,
+    pub verification_data: Vec<u8>,
+    pub precursor: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct StoredCFrag {
+    pub fragment_data: Vec<u8>,
+}
+
+/// Deserialized from StoredKeyFrag.verification_data for kFrag verification.
+#[derive(Serialize, Deserialize)]
+pub struct VerificationData {
+    pub verifying_pk: Vec<u8>,
+    pub delegating_pk: Vec<u8>,
+    pub receiving_pk: Vec<u8>,
 }

--- a/ao/contracts/src/state.rs
+++ b/ao/contracts/src/state.rs
@@ -52,8 +52,9 @@ impl ProcessState {
         Self::default()
     }
 
+    // Length-prefixed encoding prevents collisions from IDs containing the delimiter
     pub fn cap_key(kfrag_id: &str, capsule_id: &str) -> String {
-        format!("{}/{}", kfrag_id, capsule_id)
+        format!("{}:{}/{}", kfrag_id.len(), kfrag_id, capsule_id)
     }
 
     pub fn is_initialized(&self) -> bool {

--- a/client/examples/basic_usage.rs
+++ b/client/examples/basic_usage.rs
@@ -30,7 +30,7 @@ async fn main() {
     println!("--- Step 2: Create client with MockAO storage ---");
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
 
     let client = FormixClient::with_storage(
         "process_001".to_string(),

--- a/client/src/actions/di.rs
+++ b/client/src/actions/di.rs
@@ -82,7 +82,9 @@ impl DefaultActionsContainer {
 
         let mock_ao = Arc::new(MockAOClient::new());
         let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-        let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+        // Single-process setup (Owner == Holder): holder_process_id defaults to contract_id at call time.
+        // Use ContractStorageImpl::new(mock_ao, holder_id) for two-process setups.
+        let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
         let storage_service = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
 
         let controller = ControllerContainer::new(Arc::clone(&crypto_service));
@@ -145,7 +147,9 @@ impl ProductionActionsContainer {
         let crypto_service = Arc::new(CoreCryptoServiceImpl::new());
         let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&crypto_service)));
         let arweave = Arc::new(ProductionArweaveStorageService::new(arweave_client));
-        let contract = Arc::new(ContractStorageImpl::new(ao_client));
+        // Single-process setup: holder_process_id defaults to contract_id at call time.
+        // Use ContractStorageImpl::new(ao_client, holder_id) for two-process (Owner+Holder) setups.
+        let contract = Arc::new(ContractStorageImpl::new_single_process(ao_client));
         let storage_service = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
         let controller = ControllerContainer::new(Arc::clone(&crypto_service));
         let workflow_services = WorkflowServiceContainer::new(service_crypto, storage_service);

--- a/client/src/adapter/external/ao/client.rs
+++ b/client/src/adapter/external/ao/client.rs
@@ -1,56 +1,33 @@
-//! AO Network client trait
-//!
-//! This module provides the AOClient trait for abstracting AO Network communication.
+//! AO Network client trait (HyperBEAM-native)
 
 use async_trait::async_trait;
 
-use super::message::{AOResponse, Binary, ExecuteMsg, QueryMsg};
+use super::message::{AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary};
 use crate::adapter::errors::AOCommunicationError;
 
-/// AOClient trait for AO Network communication
+/// AOClient trait for HyperBEAM AO Network communication.
 ///
-/// This trait abstracts the communication with AO Network processes,
-/// enabling dependency injection and easy mocking for tests.
+/// Replaces `ao_cwao/client.rs` which used CosmWasm-style ExecuteMsg/QueryMsg.
 #[async_trait]
 pub trait AOClient: Send + Sync {
-    /// Execute a state-changing message to an AO Process
-    ///
-    /// # Arguments
-    /// * `process_id` - The AO Process ID to send the message to
-    /// * `msg` - The execute message to send
-    ///
-    /// # Returns
-    /// * `Ok(AOResponse)` - The response from the process
-    /// * `Err(AOCommunicationError)` - If the execution fails
+    /// Send a state-changing message to an AO Process.
     async fn execute(
         &self,
         process_id: &str,
-        msg: ExecuteMsg,
-    ) -> Result<AOResponse, AOCommunicationError>;
+        msg: AOExecuteMsg,
+    ) -> Result<AONativeResponse, AOCommunicationError>;
 
-    /// Query an AO Process (read-only, via dry_run)
-    ///
-    /// # Arguments
-    /// * `process_id` - The AO Process ID to query
-    /// * `msg` - The query message to send
-    ///
-    /// # Returns
-    /// * `Ok(Binary)` - The query result as binary data
-    /// * `Err(AOCommunicationError)` - If the query fails
-    async fn query(&self, process_id: &str, msg: QueryMsg) -> Result<Binary, AOCommunicationError>;
+    /// Query an AO Process (read-only, via dry_run).
+    async fn query(
+        &self,
+        process_id: &str,
+        msg: AOQueryMsg,
+    ) -> Result<Binary, AOCommunicationError>;
 
-    /// Dry-run execution (read-only state inspection)
-    ///
-    /// # Arguments
-    /// * `process_id` - The AO Process ID to dry-run against
-    /// * `msg` - The execute message to simulate
-    ///
-    /// # Returns
-    /// * `Ok(AOResponse)` - The simulated response
-    /// * `Err(AOCommunicationError)` - If the dry-run fails
+    /// Dry-run execution (state inspection without side-effects).
     async fn dry_run(
         &self,
         process_id: &str,
-        msg: ExecuteMsg,
-    ) -> Result<AOResponse, AOCommunicationError>;
+        msg: AOExecuteMsg,
+    ) -> Result<AONativeResponse, AOCommunicationError>;
 }

--- a/client/src/adapter/external/ao/config.rs
+++ b/client/src/adapter/external/ao/config.rs
@@ -50,10 +50,18 @@ impl AOConfig {
         })
     }
 
-    pub fn mu_url(&self) -> &str { &self.mu_url }
-    pub fn cu_url(&self) -> &str { &self.cu_url }
-    pub fn gateway_url(&self) -> &str { &self.gateway_url }
-    pub fn timeout_ms(&self) -> u64 { self.timeout_ms }
+    pub fn mu_url(&self) -> &str {
+        &self.mu_url
+    }
+    pub fn cu_url(&self) -> &str {
+        &self.cu_url
+    }
+    pub fn gateway_url(&self) -> &str {
+        &self.gateway_url
+    }
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_env() -> Result<Self, AOCommunicationError> {

--- a/client/src/adapter/external/ao/data_item.rs
+++ b/client/src/adapter/external/ao/data_item.rs
@@ -45,7 +45,10 @@ pub struct DataItemTag {
 }
 impl DataItemTag {
     pub fn new(name: &str, value: &str) -> Self {
-        Self { name: name.to_string(), value: value.to_string() }
+        Self {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
     }
 }
 
@@ -66,9 +69,10 @@ impl DataItemBuilder {
         target: &str,
         msg: &AOExecuteMsg,
     ) -> Result<UnsignedDataItem, AOCommunicationError> {
-        let data = serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
-            details: format!("Failed to serialize AOExecuteMsg: {e}"),
-        })?;
+        let data =
+            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize AOExecuteMsg: {e}"),
+            })?;
         let target_bytes = Self::decode_target(target)?;
         Ok(UnsignedDataItem {
             target: target_bytes,
@@ -83,9 +87,10 @@ impl DataItemBuilder {
         target: &str,
         msg: &AOExecuteMsg,
     ) -> Result<serde_json::Value, AOCommunicationError> {
-        let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
-            details: format!("Failed to serialize AOExecuteMsg: {e}"),
-        })?;
+        let data =
+            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize AOExecuteMsg: {e}"),
+            })?;
         Ok(Self::dry_run_json(target, msg.action(), &data))
     }
 
@@ -94,16 +99,20 @@ impl DataItemBuilder {
         target: &str,
         msg: &AOQueryMsg,
     ) -> Result<serde_json::Value, AOCommunicationError> {
-        let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
-            details: format!("Failed to serialize AOQueryMsg: {e}"),
-        })?;
+        let data =
+            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize AOQueryMsg: {e}"),
+            })?;
         Ok(Self::dry_run_json(target, msg.action(), &data))
     }
 
     fn decode_target(target: &str) -> Result<Vec<u8>, AOCommunicationError> {
-        let bytes = URL_SAFE_NO_PAD.decode(target).map_err(|e| {
-            AOCommunicationError::ValidationError { details: format!("Invalid base64url target: {e}") }
-        })?;
+        let bytes =
+            URL_SAFE_NO_PAD
+                .decode(target)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url target: {e}"),
+                })?;
         if bytes.len() != 32 {
             return Err(AOCommunicationError::ValidationError {
                 details: format!("Target must be 32 bytes (got {})", bytes.len()),
@@ -125,13 +134,31 @@ impl DataItemBuilder {
 
     fn dry_run_json(target: &str, action: &str, data: &str) -> serde_json::Value {
         #[derive(Serialize)]
-        struct DryRunTag { name: String, value: String }
+        struct DryRunTag {
+            name: String,
+            value: String,
+        }
         let tags: Vec<DryRunTag> = vec![
-            DryRunTag { name: "Data-Protocol".into(), value: DATA_PROTOCOL.into() },
-            DryRunTag { name: "Variant".into(), value: VARIANT.into() },
-            DryRunTag { name: "Type".into(), value: MESSAGE_TYPE.into() },
-            DryRunTag { name: "SDK".into(), value: SDK.into() },
-            DryRunTag { name: "Action".into(), value: action.into() },
+            DryRunTag {
+                name: "Data-Protocol".into(),
+                value: DATA_PROTOCOL.into(),
+            },
+            DryRunTag {
+                name: "Variant".into(),
+                value: VARIANT.into(),
+            },
+            DryRunTag {
+                name: "Type".into(),
+                value: MESSAGE_TYPE.into(),
+            },
+            DryRunTag {
+                name: "SDK".into(),
+                value: SDK.into(),
+            },
+            DryRunTag {
+                name: "Action".into(),
+                value: action.into(),
+            },
         ];
         serde_json::json!({ "Target": target, "Tags": tags, "Data": data })
     }
@@ -148,15 +175,24 @@ impl DataItemBuilder {
 /// exports or JWKs where CRT components are absent).
 #[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ArweaveJWK {
-    #[zeroize(skip)] pub kty: String,
-    #[zeroize(skip)] pub n: String,
-    #[zeroize(skip)] pub e: String,
-    #[serde(default)] pub d: String,
-    #[serde(default)] pub p: String,
-    #[serde(default)] pub q: String,
-    #[serde(default)] pub dp: String,
-    #[serde(default)] pub dq: String,
-    #[serde(default)] pub qi: String,
+    #[zeroize(skip)]
+    pub kty: String,
+    #[zeroize(skip)]
+    pub n: String,
+    #[zeroize(skip)]
+    pub e: String,
+    #[serde(default)]
+    pub d: String,
+    #[serde(default)]
+    pub p: String,
+    #[serde(default)]
+    pub q: String,
+    #[serde(default)]
+    pub dp: String,
+    #[serde(default)]
+    pub dq: String,
+    #[serde(default)]
+    pub qi: String,
 }
 
 impl std::fmt::Debug for ArweaveJWK {
@@ -203,8 +239,10 @@ impl DataItemSigner {
         }
 
         let decode = |field: &str, name: &str| -> Result<BigUint, AOCommunicationError> {
-            let bytes = URL_SAFE_NO_PAD.decode(field).map_err(|e| AOCommunicationError::ValidationError {
-                details: format!("Invalid base64url in JWK {name}: {e}"),
+            let bytes = URL_SAFE_NO_PAD.decode(field).map_err(|e| {
+                AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url in JWK {name}: {e}"),
+                }
             })?;
             Ok(BigUint::from_bytes_be(&bytes))
         };
@@ -225,19 +263,26 @@ impl DataItemSigner {
             }
         })?;
 
-        let owner_bytes = URL_SAFE_NO_PAD.decode(&jwk.n).map_err(|e| AOCommunicationError::ValidationError {
-            details: format!("Invalid base64url in JWK n: {e}"),
-        })?;
+        let owner_bytes =
+            URL_SAFE_NO_PAD
+                .decode(&jwk.n)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url in JWK n: {e}"),
+                })?;
         if owner_bytes.len() != RSA_OWNER_LENGTH {
             return Err(AOCommunicationError::ValidationError {
                 details: format!(
                     "Invalid RSA modulus length: expected {} bytes, got {}",
-                    RSA_OWNER_LENGTH, owner_bytes.len()
+                    RSA_OWNER_LENGTH,
+                    owner_bytes.len()
                 ),
             });
         }
 
-        Ok(Self { signing_key: SigningKey::<Sha256>::new(private_key), owner_bytes })
+        Ok(Self {
+            signing_key: SigningKey::<Sha256>::new(private_key),
+            owner_bytes,
+        })
     }
 
     /// Owner address: `base64url(SHA-256(owner_public_key_bytes))`

--- a/client/src/adapter/external/ao/data_item.rs
+++ b/client/src/adapter/external/ao/data_item.rs
@@ -1,6 +1,12 @@
-#![allow(clippy::disallowed_names)]
+//! ANS-104 DataItem builder and signer for HyperBEAM AO.
+//!
+//! Port of `ao_cwao/data_item.rs` with updated message types.
+//! Core changes:
+//! - `ExecuteMsg` / `QueryMsg` → `AOExecuteMsg` / `AOQueryMsg`
+//! - `action` field read directly from message struct (no match arms needed)
+//! RSA signing, ANS-104 encoding, ArweaveJWK are unchanged.
 
-use std::fmt;
+#![allow(clippy::disallowed_names)]
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -13,32 +19,26 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256, Sha384};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use super::message::{ExecuteMsg, QueryMsg};
+use super::message::{AOExecuteMsg, AOQueryMsg};
 use crate::adapter::errors::AOCommunicationError;
 
-// AO protocol constants
+// AO protocol constants (unchanged)
 const DATA_PROTOCOL: &str = "ao";
 const VARIANT: &str = "ao.TN.1";
 const MESSAGE_TYPE: &str = "Message";
 const SDK: &str = "ao";
 
-/// Tag attached to a DataItem (name-value pair)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataItemTag {
     pub name: String,
     pub value: String,
 }
-
 impl DataItemTag {
     pub fn new(name: &str, value: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            value: value.to_string(),
-        }
+        Self { name: name.to_string(), value: value.to_string() }
     }
 }
 
-/// Unsigned DataItem ready for signing (ANS-104 format)
 #[derive(Debug, Clone)]
 pub struct UnsignedDataItem {
     pub target: Vec<u8>,
@@ -47,154 +47,59 @@ pub struct UnsignedDataItem {
     pub data: Vec<u8>,
 }
 
-/// Builds AO-compatible DataItems from ExecuteMsg/QueryMsg
+/// Builds AO-compatible DataItems from `AOExecuteMsg` / `AOQueryMsg`.
 pub struct DataItemBuilder;
 
 impl DataItemBuilder {
-    /// Build an unsigned DataItem from an ExecuteMsg for MU submission
+    /// Build an unsigned DataItem from `AOExecuteMsg` for MU submission.
     pub fn build_execute(
         target: &str,
-        msg: &ExecuteMsg,
+        msg: &AOExecuteMsg,
     ) -> Result<UnsignedDataItem, AOCommunicationError> {
-        let action = Self::execute_msg_action(msg);
-        let data =
-            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
-                details: format!("Failed to serialize ExecuteMsg: {e}"),
-            })?;
-
-        let tags = Self::ao_tags(target, &action);
-
-        let target_bytes =
-            URL_SAFE_NO_PAD
-                .decode(target)
-                .map_err(|e| AOCommunicationError::ValidationError {
-                    details: format!("Invalid base64url target: {e}"),
-                })?;
-        if target_bytes.len() != 32 {
-            return Err(AOCommunicationError::ValidationError {
-                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
-            });
-        }
-
+        let data = serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
+            details: format!("Failed to serialize AOExecuteMsg: {e}"),
+        })?;
+        let target_bytes = Self::decode_target(target)?;
         Ok(UnsignedDataItem {
             target: target_bytes,
             anchor: Vec::new(),
-            tags,
+            tags: Self::ao_tags(target, &msg.action),
             data,
         })
     }
 
-    /// Build a JSON body for CU dry-run API (ExecuteMsg)
+    /// Build a JSON body for CU dry-run (AOExecuteMsg).
     pub fn build_dry_run_body(
         target: &str,
-        msg: &ExecuteMsg,
+        msg: &AOExecuteMsg,
     ) -> Result<serde_json::Value, AOCommunicationError> {
-        let action = Self::execute_msg_action(msg);
-        let data =
-            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
-                details: format!("Failed to serialize ExecuteMsg: {e}"),
-            })?;
-
-        Ok(Self::dry_run_json(target, &action, &data))
+        let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+            details: format!("Failed to serialize AOExecuteMsg: {e}"),
+        })?;
+        Ok(Self::dry_run_json(target, &msg.action, &data))
     }
 
-    /// Build a JSON body for CU dry-run API (QueryMsg)
+    /// Build a JSON body for CU dry-run (AOQueryMsg).
     pub fn build_query_body(
         target: &str,
-        msg: &QueryMsg,
+        msg: &AOQueryMsg,
     ) -> Result<serde_json::Value, AOCommunicationError> {
-        let action = Self::query_msg_action(msg);
-        let data =
-            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
-                details: format!("Failed to serialize QueryMsg: {e}"),
-            })?;
-
-        Ok(Self::dry_run_json(target, &action, &data))
+        let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+            details: format!("Failed to serialize AOQueryMsg: {e}"),
+        })?;
+        Ok(Self::dry_run_json(target, &msg.action, &data))
     }
 
-    fn execute_msg_action(msg: &ExecuteMsg) -> String {
-        match msg {
-            ExecuteMsg::DelegateKFrag { .. } => "DelegateKFrag".to_string(),
-            ExecuteMsg::DelegateCapsule { .. } => "DelegateCapsule".to_string(),
-            ExecuteMsg::SubmitKFrag { .. } => "SubmitKFrag".to_string(),
-            ExecuteMsg::SubmitCapsule { .. } => "SubmitCapsule".to_string(),
-            ExecuteMsg::Reencrypt { .. } => "Reencrypt".to_string(),
-        }
-    }
-
-    fn query_msg_action(msg: &QueryMsg) -> String {
-        match msg {
-            QueryMsg::GetCFrag { .. } => "GetCFrag".to_string(),
-            QueryMsg::ListCapsulesByKFrag { .. } => "ListCapsulesByKFrag".to_string(),
-        }
-    }
-
-    /// Build an unsigned DataItem with Read-Only tag for query via MU
-    pub fn build_read_only(
-        target: &str,
-        msg: &QueryMsg,
-    ) -> Result<UnsignedDataItem, AOCommunicationError> {
-        let action = Self::query_msg_action(msg);
-        let data =
-            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
-                details: format!("Failed to serialize QueryMsg: {e}"),
-            })?;
-
-        let mut tags = Self::ao_tags(target, &action);
-        tags.push(DataItemTag::new("Read-Only", "True"));
-
-        let target_bytes =
-            URL_SAFE_NO_PAD
-                .decode(target)
-                .map_err(|e| AOCommunicationError::ValidationError {
-                    details: format!("Invalid base64url target: {e}"),
-                })?;
-        if target_bytes.len() != 32 {
+    fn decode_target(target: &str) -> Result<Vec<u8>, AOCommunicationError> {
+        let bytes = URL_SAFE_NO_PAD.decode(target).map_err(|e| {
+            AOCommunicationError::ValidationError { details: format!("Invalid base64url target: {e}") }
+        })?;
+        if bytes.len() != 32 {
             return Err(AOCommunicationError::ValidationError {
-                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
+                details: format!("Target must be 32 bytes (got {})", bytes.len()),
             });
         }
-
-        Ok(UnsignedDataItem {
-            target: target_bytes,
-            anchor: Vec::new(),
-            tags,
-            data,
-        })
-    }
-
-    /// Build an unsigned DataItem with Read-Only tag for dry-run via MU
-    pub fn build_dry_run(
-        target: &str,
-        msg: &ExecuteMsg,
-    ) -> Result<UnsignedDataItem, AOCommunicationError> {
-        let action = Self::execute_msg_action(msg);
-        let data =
-            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
-                details: format!("Failed to serialize ExecuteMsg: {e}"),
-            })?;
-
-        let mut tags = Self::ao_tags(target, &action);
-        tags.push(DataItemTag::new("Read-Only", "True"));
-
-        let target_bytes =
-            URL_SAFE_NO_PAD
-                .decode(target)
-                .map_err(|e| AOCommunicationError::ValidationError {
-                    details: format!("Invalid base64url target: {e}"),
-                })?;
-        if target_bytes.len() != 32 {
-            return Err(AOCommunicationError::ValidationError {
-                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
-            });
-        }
-
-        Ok(UnsignedDataItem {
-            target: target_bytes,
-            anchor: Vec::new(),
-            tags,
-            data,
-        })
+        Ok(bytes)
     }
 
     fn ao_tags(target: &str, action: &str) -> Vec<DataItemTag> {
@@ -210,301 +115,143 @@ impl DataItemBuilder {
 
     fn dry_run_json(target: &str, action: &str, data: &str) -> serde_json::Value {
         #[derive(Serialize)]
-        struct DryRunTag {
-            name: String,
-            value: String,
-        }
-
+        struct DryRunTag { name: String, value: String }
         let tags: Vec<DryRunTag> = vec![
-            DryRunTag {
-                name: "Data-Protocol".to_string(),
-                value: DATA_PROTOCOL.to_string(),
-            },
-            DryRunTag {
-                name: "Variant".to_string(),
-                value: VARIANT.to_string(),
-            },
-            DryRunTag {
-                name: "Type".to_string(),
-                value: MESSAGE_TYPE.to_string(),
-            },
-            DryRunTag {
-                name: "SDK".to_string(),
-                value: SDK.to_string(),
-            },
-            DryRunTag {
-                name: "Action".to_string(),
-                value: action.to_string(),
-            },
+            DryRunTag { name: "Data-Protocol".into(), value: DATA_PROTOCOL.into() },
+            DryRunTag { name: "Variant".into(), value: VARIANT.into() },
+            DryRunTag { name: "Type".into(), value: MESSAGE_TYPE.into() },
+            DryRunTag { name: "SDK".into(), value: SDK.into() },
+            DryRunTag { name: "Action".into(), value: action.into() },
         ];
-
-        serde_json::json!({
-            "Target": target,
-            "Tags": tags,
-            "Data": data,
-        })
+        serde_json::json!({ "Target": target, "Tags": tags, "Data": data })
     }
 }
 
-/// Arweave JWK (JSON Web Key) for RSA signing
-///
-/// Secret RSA components (d, p, q, dp, dq, qi) are zeroized on drop
-/// to prevent private key material from lingering in memory.
+// ─── ArweaveJWK and DataItemSigner (unchanged from ao_cwao) ──────────────────
+// Copied verbatim - only the import path changes.
+
 #[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ArweaveJWK {
-    #[zeroize(skip)]
-    pub kty: String,
-    #[zeroize(skip)]
-    pub n: String,
-    #[zeroize(skip)]
-    pub e: String,
-    #[serde(default)]
+    #[zeroize(skip)] pub kty: String,
+    #[zeroize(skip)] pub n: String,
+    #[zeroize(skip)] pub e: String,
     pub d: String,
-    #[serde(default)]
     pub p: String,
-    #[serde(default)]
     pub q: String,
-    #[serde(default)]
     pub dp: String,
-    #[serde(default)]
     pub dq: String,
-    #[serde(default)]
     pub qi: String,
 }
 
-impl fmt::Debug for ArweaveJWK {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ArweaveJWK")
-            .field("kty", &self.kty)
-            .field("n", &format!("[{} chars]", self.n.len()))
-            .field("e", &self.e)
-            .field("d", &"[REDACTED]")
-            .field("p", &"[REDACTED]")
-            .field("q", &"[REDACTED]")
-            .field("dp", &"[REDACTED]")
-            .field("dq", &"[REDACTED]")
-            .field("qi", &"[REDACTED]")
-            .finish()
-    }
-}
-
-// ANS-104 signature type for RSA-256
-const SIG_TYPE_RSA256: u16 = 1;
-const RSA_SIG_LENGTH: usize = 512;
-const RSA_OWNER_LENGTH: usize = 512;
-
-/// Signs UnsignedDataItems with an Arweave RSA key
-#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct DataItemSigner {
-    #[zeroize(skip)]
     signing_key: SigningKey<Sha256>,
-    owner_bytes: Vec<u8>,
+    pub public_key_n: Vec<u8>,
+    pub public_key_e: Vec<u8>,
+    pub owner: String,
+    pub address: String,
 }
 
 impl DataItemSigner {
     pub fn new(jwk: &ArweaveJWK) -> Result<Self, AOCommunicationError> {
-        if jwk.kty != "RSA" {
-            return Err(AOCommunicationError::ValidationError {
-                details: "JWK kty must be RSA".to_string(),
-            });
-        }
-        if jwk.n.is_empty() || jwk.e.is_empty() || jwk.d.is_empty() {
-            return Err(AOCommunicationError::ValidationError {
-                details: "JWK missing required RSA fields".to_string(),
-            });
-        }
+        let n = URL_SAFE_NO_PAD.decode(&jwk.n).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK n decode: {e}") })?;
+        let e = URL_SAFE_NO_PAD.decode(&jwk.e).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK e decode: {e}") })?;
+        let d = URL_SAFE_NO_PAD.decode(&jwk.d).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK d decode: {e}") })?;
+        let p = URL_SAFE_NO_PAD.decode(&jwk.p).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK p decode: {e}") })?;
+        let q = URL_SAFE_NO_PAD.decode(&jwk.q).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK q decode: {e}") })?;
+        let dp = URL_SAFE_NO_PAD.decode(&jwk.dp).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK dp decode: {e}") })?;
+        let dq = URL_SAFE_NO_PAD.decode(&jwk.dq).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK dq decode: {e}") })?;
+        let qi = URL_SAFE_NO_PAD.decode(&jwk.qi).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK qi decode: {e}") })?;
 
-        let decode = |field: &str, name: &str| -> Result<BigUint, AOCommunicationError> {
-            let bytes = URL_SAFE_NO_PAD.decode(field).map_err(|e| {
-                AOCommunicationError::ValidationError {
-                    details: format!("Invalid base64url in JWK {name}: {e}"),
-                }
-            })?;
-            Ok(BigUint::from_bytes_be(&bytes))
-        };
+        let private_key = RsaPrivateKey::from_components(
+            BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e),
+            BigUint::from_bytes_be(&d),
+            vec![BigUint::from_bytes_be(&p), BigUint::from_bytes_be(&q)],
+        ).map_err(|e| AOCommunicationError::SigningError { details: format!("RSA key: {e}") })?;
 
-        let n = decode(&jwk.n, "n")?;
-        let e = decode(&jwk.e, "e")?;
-        let d = decode(&jwk.d, "d")?;
+        let _ = (dp, dq, qi); // consumed; used for key validation only
 
-        let mut primes = Vec::new();
-        if !jwk.p.is_empty() && !jwk.q.is_empty() {
-            primes.push(decode(&jwk.p, "p")?);
-            primes.push(decode(&jwk.q, "q")?);
-        }
-
-        let private_key = RsaPrivateKey::from_components(n, e, d, primes).map_err(|e| {
-            AOCommunicationError::ValidationError {
-                details: format!("Invalid RSA key: {e}"),
-            }
-        })?;
-
-        let owner_bytes =
-            URL_SAFE_NO_PAD
-                .decode(&jwk.n)
-                .map_err(|e| AOCommunicationError::ValidationError {
-                    details: format!("Invalid base64url in JWK n: {e}"),
-                })?;
-        if owner_bytes.len() != RSA_OWNER_LENGTH {
-            return Err(AOCommunicationError::ValidationError {
-                details: format!(
-                    "Invalid RSA modulus length: expected {} bytes, got {}",
-                    RSA_OWNER_LENGTH,
-                    owner_bytes.len()
-                ),
-            });
-        }
-
-        let signing_key = SigningKey::<Sha256>::new(private_key);
+        let owner = URL_SAFE_NO_PAD.encode(&n);
+        let mut hasher = Sha256::new();
+        hasher.update(&n);
+        let address = URL_SAFE_NO_PAD.encode(hasher.finalize());
 
         Ok(Self {
-            signing_key,
-            owner_bytes,
+            signing_key: SigningKey::new(private_key),
+            public_key_n: n,
+            public_key_e: e,
+            owner,
+            address,
         })
     }
 
-    /// Sign a DataItem and return complete ANS-104 signed bytes
     pub fn sign(&self, item: &UnsignedDataItem) -> Result<Vec<u8>, AOCommunicationError> {
-        let deep_hash = self.build_deep_hash(item);
-        let signature = self.signing_key.sign_with_rng(&mut OsRng, &deep_hash);
-        let sig_bytes = signature.to_bytes();
-
-        let mut result = Vec::new();
-
-        // Signature type (2 bytes, little-endian)
-        result.extend_from_slice(&SIG_TYPE_RSA256.to_le_bytes());
-
-        // Signature (512 bytes, zero-padded)
-        let mut sig_padded = vec![0u8; RSA_SIG_LENGTH];
-        let sig_vec = sig_bytes.to_vec();
-        let start = RSA_SIG_LENGTH.saturating_sub(sig_vec.len());
-        sig_padded[start..].copy_from_slice(&sig_vec);
-        result.extend_from_slice(&sig_padded);
-
-        // Owner (512 bytes, zero-padded)
-        let mut owner_padded = vec![0u8; RSA_OWNER_LENGTH];
-        let start = RSA_OWNER_LENGTH.saturating_sub(self.owner_bytes.len());
-        owner_padded[start..].copy_from_slice(&self.owner_bytes);
-        result.extend_from_slice(&owner_padded);
-
-        // Target
-        if item.target.is_empty() {
-            result.push(0);
-        } else {
-            result.push(1);
-            result.extend_from_slice(&item.target);
-        }
-
-        // Anchor
-        if item.anchor.is_empty() {
-            result.push(0);
-        } else {
-            result.push(1);
-            result.extend_from_slice(&item.anchor);
-        }
-
-        // Tags
-        let tags_bytes = self.serialize_avro_tags(&item.tags);
-        let num_tags = item.tags.len() as u64;
-        result.extend_from_slice(&num_tags.to_le_bytes());
-        result.extend_from_slice(&(tags_bytes.len() as u64).to_le_bytes());
-        result.extend_from_slice(&tags_bytes);
-
-        // Data
-        result.extend_from_slice(&item.data);
-
-        Ok(result)
+        let to_sign = self.build_signable(item)?;
+        let mut rng = OsRng;
+        let signature = self.signing_key.sign_with_rng(&mut rng, &to_sign);
+        self.encode_data_item(item, signature.to_bytes().as_ref())
     }
 
-    /// Owner address: base64url(SHA-256(owner_public_key_bytes))
-    pub fn owner_address(&self) -> String {
-        let hash = Sha256::digest(&self.owner_bytes);
-        URL_SAFE_NO_PAD.encode(hash)
-    }
-
-    /// ANS-104 deep hash: SHA-384-based recursive tree hash
-    fn build_deep_hash(&self, item: &UnsignedDataItem) -> Vec<u8> {
-        let tags_bytes = self.serialize_avro_tags(&item.tags);
-        let sig_type_str = SIG_TYPE_RSA256.to_string();
-
-        let parts: Vec<&[u8]> = vec![
-            b"dataitem",
-            b"1",
-            sig_type_str.as_bytes(),
-            &self.owner_bytes,
-            &item.target,
-            &item.anchor,
-            &tags_bytes,
-            &item.data,
-        ];
-
-        let hashed_parts: Vec<[u8; 48]> = parts.iter().map(|p| Self::deep_hash_blob(p)).collect();
-        Self::deep_hash_list(&hashed_parts).to_vec()
-    }
-
-    fn deep_hash_blob(data: &[u8]) -> [u8; 48] {
-        let mut tag = Vec::new();
-        tag.extend_from_slice(b"blob");
-        tag.extend_from_slice(data.len().to_string().as_bytes());
-
-        let tag_hash = Sha384::digest(&tag);
-        let data_hash = Sha384::digest(data);
-
-        let mut combined = Vec::with_capacity(96);
-        combined.extend_from_slice(&tag_hash);
-        combined.extend_from_slice(&data_hash);
-        Sha384::digest(&combined).into()
-    }
-
-    fn deep_hash_list(items: &[[u8; 48]]) -> [u8; 48] {
-        let mut tag = Vec::new();
-        tag.extend_from_slice(b"list");
-        tag.extend_from_slice(items.len().to_string().as_bytes());
-
-        let mut acc: [u8; 48] = Sha384::digest(&tag).into();
-
-        for item in items {
-            let mut combined = Vec::with_capacity(96);
-            combined.extend_from_slice(&acc);
-            combined.extend_from_slice(item);
-            acc = Sha384::digest(&combined).into();
+    fn build_signable(&self, item: &UnsignedDataItem) -> Result<Vec<u8>, AOCommunicationError> {
+        let mut hasher = Sha384::new();
+        // Deep hash: tags
+        for tag in &item.tags {
+            hasher.update(tag.name.as_bytes());
+            hasher.update(b":");
+            hasher.update(tag.value.as_bytes());
+            hasher.update(b",");
         }
-
-        acc
+        // target + data
+        hasher.update(&item.target);
+        hasher.update(&item.data);
+        Ok(hasher.finalize().to_vec())
     }
 
-    fn serialize_avro_tags(&self, tags: &[DataItemTag]) -> Vec<u8> {
-        if tags.is_empty() {
-            return Vec::new();
+    fn encode_data_item(
+        &self,
+        item: &UnsignedDataItem,
+        signature: &[u8],
+    ) -> Result<Vec<u8>, AOCommunicationError> {
+        use std::io::Write;
+        let mut out = Vec::new();
+        // signature type (Arweave RSA = 1, u16 LE)
+        out.write_all(&1u16.to_le_bytes())
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // signature (512 bytes)
+        out.write_all(signature)
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // owner (512 bytes, zero-padded)
+        let mut owner_bytes = self.public_key_n.clone();
+        owner_bytes.resize(512, 0);
+        out.write_all(&owner_bytes)
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // target present flag + target (32 bytes)
+        out.write_all(&[1u8])
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        out.write_all(&item.target)
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // anchor present flag
+        out.write_all(&[0u8])
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // tags count (u64 LE)
+        let tag_count = item.tags.len() as u64;
+        out.write_all(&tag_count.to_le_bytes())
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        // tags (AVSc encoded - simplified: length-prefixed name/value)
+        for tag in &item.tags {
+            let name = tag.name.as_bytes();
+            let value = tag.value.as_bytes();
+            out.write_all(&(name.len() as u64).to_le_bytes())
+                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+            out.write_all(name)
+                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+            out.write_all(&(value.len() as u64).to_le_bytes())
+                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+            out.write_all(value)
+                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
         }
-
-        let mut buf = Vec::new();
-        #[allow(clippy::cast_possible_wrap)]
-        Self::avro_encode_long(&mut buf, tags.len() as i64);
-        for tag in tags {
-            let name_bytes = tag.name.as_bytes();
-            let value_bytes = tag.value.as_bytes();
-            #[allow(clippy::cast_possible_wrap)]
-            Self::avro_encode_long(&mut buf, name_bytes.len() as i64);
-            buf.extend_from_slice(name_bytes);
-            #[allow(clippy::cast_possible_wrap)]
-            Self::avro_encode_long(&mut buf, value_bytes.len() as i64);
-            buf.extend_from_slice(value_bytes);
-        }
-        Self::avro_encode_long(&mut buf, 0);
-        buf
-    }
-
-    fn avro_encode_long(buf: &mut Vec<u8>, val: i64) {
-        #[allow(clippy::cast_sign_loss)]
-        let mut v = ((val << 1) ^ (val >> 63)) as u64;
-        loop {
-            if v & !0x7F == 0 {
-                buf.push(v as u8);
-                break;
-            }
-            buf.push((v as u8 & 0x7F) | 0x80);
-            v >>= 7;
-        }
+        // data
+        out.write_all(&item.data)
+            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+        Ok(out)
     }
 }

--- a/client/src/adapter/external/ao/data_item.rs
+++ b/client/src/adapter/external/ao/data_item.rs
@@ -3,8 +3,13 @@
 //! Port of `ao_cwao/data_item.rs` with updated message types.
 //! Core changes:
 //! - `ExecuteMsg` / `QueryMsg` → `AOExecuteMsg` / `AOQueryMsg`
-//! - `action` field read directly from message struct (no match arms needed)
-//! RSA signing, ANS-104 encoding, ArweaveJWK are unchanged.
+//! - `action` read via `.action()` accessor (private field)
+//!
+//! Signing and ANS-104 encoding are IDENTICAL to ao_cwao — do not diverge.
+//! Specifically:
+//!   - Deep-hash (SHA-384 recursive tree) is preserved exactly
+//!   - Tags are Avro-encoded (zigzag varint + block encoding)
+//!   - RSA signature / owner padding is 512-byte zero-padded
 
 #![allow(clippy::disallowed_names)]
 
@@ -27,6 +32,11 @@ const DATA_PROTOCOL: &str = "ao";
 const VARIANT: &str = "ao.TN.1";
 const MESSAGE_TYPE: &str = "Message";
 const SDK: &str = "ao";
+
+// ANS-104 constants (must match ao_cwao)
+const SIG_TYPE_RSA256: u16 = 1;
+const RSA_SIG_LENGTH: usize = 512;
+const RSA_OWNER_LENGTH: usize = 512;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataItemTag {
@@ -63,7 +73,7 @@ impl DataItemBuilder {
         Ok(UnsignedDataItem {
             target: target_bytes,
             anchor: Vec::new(),
-            tags: Self::ao_tags(target, &msg.action),
+            tags: Self::ao_tags(target, msg.action()),
             data,
         })
     }
@@ -76,7 +86,7 @@ impl DataItemBuilder {
         let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
             details: format!("Failed to serialize AOExecuteMsg: {e}"),
         })?;
-        Ok(Self::dry_run_json(target, &msg.action, &data))
+        Ok(Self::dry_run_json(target, msg.action(), &data))
     }
 
     /// Build a JSON body for CU dry-run (AOQueryMsg).
@@ -87,7 +97,7 @@ impl DataItemBuilder {
         let data = serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
             details: format!("Failed to serialize AOQueryMsg: {e}"),
         })?;
-        Ok(Self::dry_run_json(target, &msg.action, &data))
+        Ok(Self::dry_run_json(target, msg.action(), &data))
     }
 
     fn decode_target(target: &str) -> Result<Vec<u8>, AOCommunicationError> {
@@ -127,131 +137,255 @@ impl DataItemBuilder {
     }
 }
 
-// ─── ArweaveJWK and DataItemSigner (unchanged from ao_cwao) ──────────────────
-// Copied verbatim - only the import path changes.
+// ─── ArweaveJWK ───────────────────────────────────────────────────────────────
 
+/// Arweave JWK (JSON Web Key) for RSA signing.
+///
+/// Secret fields are zeroized on drop to prevent private key material from
+/// lingering in memory.
+///
+/// `p/q/dp/dq/qi` have `#[serde(default)]` to accept minimal JWKs (e.g. public-key only
+/// exports or JWKs where CRT components are absent).
 #[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ArweaveJWK {
     #[zeroize(skip)] pub kty: String,
     #[zeroize(skip)] pub n: String,
     #[zeroize(skip)] pub e: String,
-    pub d: String,
-    pub p: String,
-    pub q: String,
-    pub dp: String,
-    pub dq: String,
-    pub qi: String,
+    #[serde(default)] pub d: String,
+    #[serde(default)] pub p: String,
+    #[serde(default)] pub q: String,
+    #[serde(default)] pub dp: String,
+    #[serde(default)] pub dq: String,
+    #[serde(default)] pub qi: String,
 }
 
+impl std::fmt::Debug for ArweaveJWK {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArweaveJWK")
+            .field("kty", &self.kty)
+            .field("n", &format!("[{} chars]", self.n.len()))
+            .field("e", &self.e)
+            .field("d", &"[REDACTED]")
+            .field("p", &"[REDACTED]")
+            .field("q", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+// ─── DataItemSigner ───────────────────────────────────────────────────────────
+// Identical to ao_cwao/data_item.rs — must not diverge.
+
+/// Signs UnsignedDataItems with an Arweave RSA key using ANS-104 format.
+///
+/// Wire format details:
+/// - Signature: RSA-PSS-SHA256, 512-byte zero-padded
+/// - Owner: RSA modulus (n), 512-byte zero-padded
+/// - Tags: Avro block encoding (zigzag varint lengths)
+/// - Hash: ANS-104 deep-hash (SHA-384 recursive tree)
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct DataItemSigner {
+    #[zeroize(skip)]
     signing_key: SigningKey<Sha256>,
-    pub public_key_n: Vec<u8>,
-    pub public_key_e: Vec<u8>,
-    pub owner: String,
-    pub address: String,
+    owner_bytes: Vec<u8>,
 }
 
 impl DataItemSigner {
     pub fn new(jwk: &ArweaveJWK) -> Result<Self, AOCommunicationError> {
-        let n = URL_SAFE_NO_PAD.decode(&jwk.n).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK n decode: {e}") })?;
-        let e = URL_SAFE_NO_PAD.decode(&jwk.e).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK e decode: {e}") })?;
-        let d = URL_SAFE_NO_PAD.decode(&jwk.d).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK d decode: {e}") })?;
-        let p = URL_SAFE_NO_PAD.decode(&jwk.p).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK p decode: {e}") })?;
-        let q = URL_SAFE_NO_PAD.decode(&jwk.q).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK q decode: {e}") })?;
-        let dp = URL_SAFE_NO_PAD.decode(&jwk.dp).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK dp decode: {e}") })?;
-        let dq = URL_SAFE_NO_PAD.decode(&jwk.dq).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK dq decode: {e}") })?;
-        let qi = URL_SAFE_NO_PAD.decode(&jwk.qi).map_err(|e| AOCommunicationError::ValidationError { details: format!("JWK qi decode: {e}") })?;
+        if jwk.kty != "RSA" {
+            return Err(AOCommunicationError::ValidationError {
+                details: "JWK kty must be RSA".to_string(),
+            });
+        }
+        if jwk.n.is_empty() || jwk.e.is_empty() || jwk.d.is_empty() {
+            return Err(AOCommunicationError::ValidationError {
+                details: "JWK missing required RSA fields (n, e, d)".to_string(),
+            });
+        }
 
-        let private_key = RsaPrivateKey::from_components(
-            BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e),
-            BigUint::from_bytes_be(&d),
-            vec![BigUint::from_bytes_be(&p), BigUint::from_bytes_be(&q)],
-        ).map_err(|e| AOCommunicationError::SigningError { details: format!("RSA key: {e}") })?;
+        let decode = |field: &str, name: &str| -> Result<BigUint, AOCommunicationError> {
+            let bytes = URL_SAFE_NO_PAD.decode(field).map_err(|e| AOCommunicationError::ValidationError {
+                details: format!("Invalid base64url in JWK {name}: {e}"),
+            })?;
+            Ok(BigUint::from_bytes_be(&bytes))
+        };
 
-        let _ = (dp, dq, qi); // consumed; used for key validation only
+        let n = decode(&jwk.n, "n")?;
+        let e = decode(&jwk.e, "e")?;
+        let d = decode(&jwk.d, "d")?;
 
-        let owner = URL_SAFE_NO_PAD.encode(&n);
-        let mut hasher = Sha256::new();
-        hasher.update(&n);
-        let address = URL_SAFE_NO_PAD.encode(hasher.finalize());
+        let mut primes = Vec::new();
+        if !jwk.p.is_empty() && !jwk.q.is_empty() {
+            primes.push(decode(&jwk.p, "p")?);
+            primes.push(decode(&jwk.q, "q")?);
+        }
 
-        Ok(Self {
-            signing_key: SigningKey::new(private_key),
-            public_key_n: n,
-            public_key_e: e,
-            owner,
-            address,
-        })
+        let private_key = RsaPrivateKey::from_components(n, e, d, primes).map_err(|e| {
+            AOCommunicationError::ValidationError {
+                details: format!("Invalid RSA key: {e}"),
+            }
+        })?;
+
+        let owner_bytes = URL_SAFE_NO_PAD.decode(&jwk.n).map_err(|e| AOCommunicationError::ValidationError {
+            details: format!("Invalid base64url in JWK n: {e}"),
+        })?;
+        if owner_bytes.len() != RSA_OWNER_LENGTH {
+            return Err(AOCommunicationError::ValidationError {
+                details: format!(
+                    "Invalid RSA modulus length: expected {} bytes, got {}",
+                    RSA_OWNER_LENGTH, owner_bytes.len()
+                ),
+            });
+        }
+
+        Ok(Self { signing_key: SigningKey::<Sha256>::new(private_key), owner_bytes })
     }
 
+    /// Owner address: `base64url(SHA-256(owner_public_key_bytes))`
+    pub fn owner_address(&self) -> String {
+        URL_SAFE_NO_PAD.encode(Sha256::digest(&self.owner_bytes))
+    }
+
+    /// Sign a DataItem and return complete ANS-104 signed bytes.
     pub fn sign(&self, item: &UnsignedDataItem) -> Result<Vec<u8>, AOCommunicationError> {
-        let to_sign = self.build_signable(item)?;
-        let mut rng = OsRng;
-        let signature = self.signing_key.sign_with_rng(&mut rng, &to_sign);
-        self.encode_data_item(item, signature.to_bytes().as_ref())
+        let deep_hash = self.build_deep_hash(item);
+        let signature = self.signing_key.sign_with_rng(&mut OsRng, &deep_hash);
+        let sig_bytes = signature.to_bytes();
+
+        let mut result = Vec::new();
+
+        // Signature type (2 bytes, little-endian)
+        result.extend_from_slice(&SIG_TYPE_RSA256.to_le_bytes());
+
+        // Signature (512 bytes, zero-padded to the right)
+        let mut sig_padded = vec![0u8; RSA_SIG_LENGTH];
+        let sig_vec = sig_bytes.to_vec();
+        let start = RSA_SIG_LENGTH.saturating_sub(sig_vec.len());
+        sig_padded[start..].copy_from_slice(&sig_vec);
+        result.extend_from_slice(&sig_padded);
+
+        // Owner (512 bytes, zero-padded)
+        let mut owner_padded = vec![0u8; RSA_OWNER_LENGTH];
+        let start = RSA_OWNER_LENGTH.saturating_sub(self.owner_bytes.len());
+        owner_padded[start..].copy_from_slice(&self.owner_bytes);
+        result.extend_from_slice(&owner_padded);
+
+        // Target present flag + bytes (32 bytes)
+        if item.target.is_empty() {
+            result.push(0);
+        } else {
+            result.push(1);
+            result.extend_from_slice(&item.target);
+        }
+
+        // Anchor present flag + bytes (32 bytes)
+        if item.anchor.is_empty() {
+            result.push(0);
+        } else {
+            result.push(1);
+            result.extend_from_slice(&item.anchor);
+        }
+
+        // Tags: num_tags (u64 LE) + tags_bytes_len (u64 LE) + Avro-encoded tags
+        let tags_bytes = self.serialize_avro_tags(&item.tags);
+        let num_tags = item.tags.len() as u64;
+        result.extend_from_slice(&num_tags.to_le_bytes());
+        result.extend_from_slice(&(tags_bytes.len() as u64).to_le_bytes());
+        result.extend_from_slice(&tags_bytes);
+
+        // Data
+        result.extend_from_slice(&item.data);
+
+        Ok(result)
     }
 
-    fn build_signable(&self, item: &UnsignedDataItem) -> Result<Vec<u8>, AOCommunicationError> {
-        let mut hasher = Sha384::new();
-        // Deep hash: tags
-        for tag in &item.tags {
-            hasher.update(tag.name.as_bytes());
-            hasher.update(b":");
-            hasher.update(tag.value.as_bytes());
-            hasher.update(b",");
-        }
-        // target + data
-        hasher.update(&item.target);
-        hasher.update(&item.data);
-        Ok(hasher.finalize().to_vec())
+    // ─── ANS-104 deep-hash ────────────────────────────────────────────────────
+    // Identical to ao_cwao — SHA-384 recursive tree hash.
+    // Reference: https://github.com/ArweaveTeam/arweave-standards/blob/master/ans/ANS-104.md
+
+    fn build_deep_hash(&self, item: &UnsignedDataItem) -> Vec<u8> {
+        let tags_bytes = self.serialize_avro_tags(&item.tags);
+        let sig_type_str = SIG_TYPE_RSA256.to_string();
+
+        let parts: Vec<&[u8]> = vec![
+            b"dataitem",
+            b"1",
+            sig_type_str.as_bytes(),
+            &self.owner_bytes,
+            &item.target,
+            &item.anchor,
+            &tags_bytes,
+            &item.data,
+        ];
+
+        let hashed_parts: Vec<[u8; 48]> = parts.iter().map(|p| Self::deep_hash_blob(p)).collect();
+        Self::deep_hash_list(&hashed_parts).to_vec()
     }
 
-    fn encode_data_item(
-        &self,
-        item: &UnsignedDataItem,
-        signature: &[u8],
-    ) -> Result<Vec<u8>, AOCommunicationError> {
-        use std::io::Write;
-        let mut out = Vec::new();
-        // signature type (Arweave RSA = 1, u16 LE)
-        out.write_all(&1u16.to_le_bytes())
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // signature (512 bytes)
-        out.write_all(signature)
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // owner (512 bytes, zero-padded)
-        let mut owner_bytes = self.public_key_n.clone();
-        owner_bytes.resize(512, 0);
-        out.write_all(&owner_bytes)
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // target present flag + target (32 bytes)
-        out.write_all(&[1u8])
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        out.write_all(&item.target)
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // anchor present flag
-        out.write_all(&[0u8])
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // tags count (u64 LE)
-        let tag_count = item.tags.len() as u64;
-        out.write_all(&tag_count.to_le_bytes())
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        // tags (AVSc encoded - simplified: length-prefixed name/value)
-        for tag in &item.tags {
-            let name = tag.name.as_bytes();
-            let value = tag.value.as_bytes();
-            out.write_all(&(name.len() as u64).to_le_bytes())
-                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-            out.write_all(name)
-                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-            out.write_all(&(value.len() as u64).to_le_bytes())
-                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-            out.write_all(value)
-                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+    fn deep_hash_blob(data: &[u8]) -> [u8; 48] {
+        let mut tag = Vec::new();
+        tag.extend_from_slice(b"blob");
+        tag.extend_from_slice(data.len().to_string().as_bytes());
+
+        let tag_hash = Sha384::digest(&tag);
+        let data_hash = Sha384::digest(data);
+
+        let mut combined = Vec::with_capacity(96);
+        combined.extend_from_slice(&tag_hash);
+        combined.extend_from_slice(&data_hash);
+        Sha384::digest(&combined).into()
+    }
+
+    fn deep_hash_list(items: &[[u8; 48]]) -> [u8; 48] {
+        let mut tag = Vec::new();
+        tag.extend_from_slice(b"list");
+        tag.extend_from_slice(items.len().to_string().as_bytes());
+
+        let mut acc: [u8; 48] = Sha384::digest(&tag).into();
+        for item in items {
+            let mut combined = Vec::with_capacity(96);
+            combined.extend_from_slice(&acc);
+            combined.extend_from_slice(item);
+            acc = Sha384::digest(&combined).into();
         }
-        // data
-        out.write_all(&item.data)
-            .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
-        Ok(out)
+        acc
+    }
+
+    // ─── Avro tag encoding ────────────────────────────────────────────────────
+    // ANS-104 tags use Avro object container format (zigzag varint lengths).
+    // Identical to ao_cwao — must not diverge.
+
+    fn serialize_avro_tags(&self, tags: &[DataItemTag]) -> Vec<u8> {
+        if tags.is_empty() {
+            return Vec::new();
+        }
+        let mut buf = Vec::new();
+        #[allow(clippy::cast_possible_wrap)]
+        Self::avro_encode_long(&mut buf, tags.len() as i64);
+        for tag in tags {
+            let name_bytes = tag.name.as_bytes();
+            let value_bytes = tag.value.as_bytes();
+            #[allow(clippy::cast_possible_wrap)]
+            Self::avro_encode_long(&mut buf, name_bytes.len() as i64);
+            buf.extend_from_slice(name_bytes);
+            #[allow(clippy::cast_possible_wrap)]
+            Self::avro_encode_long(&mut buf, value_bytes.len() as i64);
+            buf.extend_from_slice(value_bytes);
+        }
+        Self::avro_encode_long(&mut buf, 0); // end-of-block marker
+        buf
+    }
+
+    fn avro_encode_long(buf: &mut Vec<u8>, val: i64) {
+        // Zigzag encoding
+        #[allow(clippy::cast_sign_loss)]
+        let mut v = ((val << 1) ^ (val >> 63)) as u64;
+        loop {
+            if v & !0x7F == 0 {
+                buf.push(v as u8);
+                break;
+            }
+            buf.push((v as u8 & 0x7F) | 0x80);
+            v >>= 7;
+        }
     }
 }

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -1,527 +1,196 @@
-//! AO Message types for client-side communication
+//! AO-native message types for HyperBEAM communication.
 //!
-//! This module defines message types for communicating with AO Network processes.
-//! Types are duplicated from `ao/contracts/src/msg.rs` for client independence.
+//! Replaces the CosmWasm-style enum messages in `ao_cwao/message.rs`.
+//! New format: `{ "action": "...", "data": { ... } }` for both execute and query.
+//!
+//! The Binary type and validation helpers are carried over from ao_cwao.
 
 use serde::{Deserialize, Serialize};
 
-// =====================================================================
-// Binary wrapper type
-// =====================================================================
+// ─── Binary (unchanged from ao_cwao) ─────────────────────────────────────────
 
-/// Binary data wrapper for serialization
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub struct Binary(#[serde(with = "base64_serde")] pub Vec<u8>);
 
 impl Binary {
-    /// Create a new Binary from bytes
-    pub fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
-
-    /// Get the underlying bytes as a slice
-    pub fn as_slice(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// Get the length of the binary data
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Check if the binary data is empty
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Consume and return the underlying Vec
-    pub fn into_vec(self) -> Vec<u8> {
-        self.0
-    }
+    pub fn new(bytes: Vec<u8>) -> Self { Self(bytes) }
+    pub fn as_slice(&self) -> &[u8] { &self.0 }
+    pub fn len(&self) -> usize { self.0.len() }
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub fn into_vec(self) -> Vec<u8> { self.0 }
 }
-
 impl From<Vec<u8>> for Binary {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
+    fn from(bytes: Vec<u8>) -> Self { Self(bytes) }
 }
-
 impl From<&[u8]> for Binary {
-    fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
-    }
+    fn from(bytes: &[u8]) -> Self { Self(bytes.to_vec()) }
 }
-
 impl AsRef<[u8]> for Binary {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
+    fn as_ref(&self) -> &[u8] { &self.0 }
 }
 
 mod base64_serde {
     use base64::{engine::general_purpose::STANDARD, Engine};
     use serde::{Deserialize, Deserializer, Serializer};
-
     pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    where S: Serializer {
         serializer.serialize_str(&STANDARD.encode(bytes))
     }
-
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    where D: Deserializer<'de> {
         let s = String::deserialize(deserializer)?;
         STANDARD.decode(&s).map_err(serde::de::Error::custom)
     }
 }
 
-// =====================================================================
-// Execute Messages (state-changing operations)
-// =====================================================================
+// ─── AO-native Execute Message ───────────────────────────────────────────────
 
-/// Execute messages for state-changing operations on AO processes
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum ExecuteMsg {
-    /// Delegate a KFrag to the Owner-Process
-    DelegateKFrag { kfrag_id: String, kfrag: Binary },
-
-    /// Delegate a Capsule along with its associated KFrag
-    DelegateCapsule {
-        kfrag_id: String,
-        capsule_id: String,
-        capsule: Binary,
-    },
-
-    /// Submit a KFrag to a Holder-Process
-    SubmitKFrag { kfrag_id: String, kfrag: Binary },
-
-    /// Submit a Capsule to a Holder-Process
-    SubmitCapsule {
-        kfrag_id: String,
-        capsule_id: String,
-        capsule: Binary,
-    },
-
-    /// Request re-encryption of a Capsule
-    Reencrypt {
-        kfrag_id: String,
-        capsule_id: String,
-    },
+/// Execute message for state-changing operations (HyperBEAM format).
+/// Serializes as: `{ "action": "DelegateKFrag", "data": { ... } }`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AOExecuteMsg {
+    pub action: String,
+    pub data: serde_json::Value,
 }
 
-// =====================================================================
-// Query Messages (read-only operations)
-// =====================================================================
+impl AOExecuteMsg {
+    /// Delegate a kFrag to the Holder-Process.
+    pub fn delegate_kfrag(kfrag_id: impl Into<String>, kfrag: Vec<u8>) -> Self {
+        Self {
+            action: "DelegateKFrag".to_string(),
+            data: serde_json::json!({
+                "kfrag_id": kfrag_id.into(),
+                "kfrag": kfrag,
+            }),
+        }
+    }
 
-/// Query messages for read-only operations on AO processes
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum QueryMsg {
-    /// Get a CFrag for a specific KFrag and Capsule
-    GetCFrag {
-        kfrag_id: String,
-        capsule_id: String,
-    },
+    /// Delegate a Capsule along with its associated kFrag.
+    pub fn delegate_capsule(
+        kfrag_id: impl Into<String>,
+        capsule_id: impl Into<String>,
+        capsule: Vec<u8>,
+        holder_process_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            action: "DelegateCapsule".to_string(),
+            data: serde_json::json!({
+                "kfrag_id": kfrag_id.into(),
+                "capsule_id": capsule_id.into(),
+                "capsule": capsule,
+                "holder_process_id": holder_process_id.into(),
+            }),
+        }
+    }
 
-    /// List all Capsules associated with a KFrag
-    ListCapsulesByKFrag {
-        kfrag_id: String,
+    /// Retry re-encryption for a specific (kfrag_id, capsule_id) pair.
+    pub fn reencrypt(kfrag_id: impl Into<String>, capsule_id: impl Into<String>) -> Self {
+        Self {
+            action: "Reencrypt".to_string(),
+            data: serde_json::json!({
+                "kfrag_id": kfrag_id.into(),
+                "capsule_id": capsule_id.into(),
+            }),
+        }
+    }
+}
+
+// ─── AO-native Query Message ─────────────────────────────────────────────────
+
+/// Query message for read-only operations (HyperBEAM format).
+/// Serializes as: `{ "action": "GetCFrag", "data": { ... } }`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AOQueryMsg {
+    pub action: String,
+    pub data: serde_json::Value,
+}
+
+impl AOQueryMsg {
+    /// Get a cFrag for a specific kFrag and Capsule pair.
+    pub fn get_cfrag(kfrag_id: impl Into<String>, capsule_id: impl Into<String>) -> Self {
+        Self {
+            action: "GetCFrag".to_string(),
+            data: serde_json::json!({
+                "kfrag_id": kfrag_id.into(),
+                "capsule_id": capsule_id.into(),
+            }),
+        }
+    }
+
+    /// List Capsules associated with a kFrag (with optional pagination).
+    pub fn list_capsules_by_kfrag(
+        kfrag_id: impl Into<String>,
         start_after: Option<String>,
         limit: Option<u32>,
-    },
+    ) -> Self {
+        Self {
+            action: "ListCapsules".to_string(),
+            data: serde_json::json!({
+                "kfrag_id": kfrag_id.into(),
+                "start_after": start_after,
+                "limit": limit,
+            }),
+        }
+    }
 }
 
-// =====================================================================
-// Response types
-// =====================================================================
+// ─── AO-native Response ───────────────────────────────────────────────────────
 
-/// Response from AO Process execution
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct AOResponse {
-    /// Whether the execution succeeded
-    pub success: bool,
-    /// Response data (if any)
-    pub data: Option<Binary>,
-    /// Events emitted during execution
-    pub events: Vec<AOEvent>,
-    /// MU-returned message ID for AO Link verification
+/// Response from AO-native contract (HyperBEAM format).
+/// Mirrors `ao/contracts/src/message.rs :: AOResponse`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AONativeResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Message ID returned from AO MU
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
 }
 
-impl AOResponse {
-    /// Create a successful response with no data
-    pub fn success() -> Self {
-        Self {
-            success: true,
-            data: None,
-            events: Vec::new(),
-            message_id: None,
-        }
+impl AONativeResponse {
+    pub fn success(data: serde_json::Value) -> Self {
+        Self { ok: true, data: Some(data), error: None, message_id: None }
     }
-
-    /// Create a successful response with data
-    pub fn success_with_data(value: Binary) -> Self {
-        Self {
-            success: true,
-            data: Some(value),
-            events: Vec::new(),
-            message_id: None,
-        }
-    }
-
-    /// Create a successful response with events
-    pub fn success_with_events(events: Vec<AOEvent>) -> Self {
-        Self {
-            success: true,
-            data: None,
-            events,
-            message_id: None,
-        }
-    }
-
-    /// Add an event to the response
-    pub fn add_event(&mut self, event: AOEvent) {
-        self.events.push(event);
+    pub fn success_empty() -> Self {
+        Self { ok: true, data: None, error: None, message_id: None }
     }
 }
 
-/// Event emitted during AO execution
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct AOEvent {
-    /// Type of the event
-    pub event_type: String,
-    /// Attributes associated with the event
-    pub attributes: Vec<AOAttribute>,
-}
+// ─── Response sub-types (for GetCFrag deserialization) ───────────────────────
 
-impl AOEvent {
-    /// Create a new event
-    pub fn new(event_type: &str) -> Self {
-        Self {
-            event_type: event_type.to_string(),
-            attributes: Vec::new(),
-        }
-    }
-
-    /// Add an attribute to the event
-    pub fn add_attribute(&mut self, key: &str, value: &str) {
-        self.attributes.push(AOAttribute {
-            key: key.to_string(),
-            value: value.to_string(),
-        });
-    }
-
-    /// Create an event with attributes
-    pub fn with_attributes(event_type: &str, attributes: Vec<(&str, &str)>) -> Self {
-        Self {
-            event_type: event_type.to_string(),
-            attributes: attributes
-                .into_iter()
-                .map(|(k, v)| AOAttribute {
-                    key: k.to_string(),
-                    value: v.to_string(),
-                })
-                .collect(),
-        }
-    }
-}
-
-/// Attribute of an AO event
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct AOAttribute {
-    /// Attribute key
-    pub key: String,
-    /// Attribute value
-    pub value: String,
-}
-
-/// Response for GetCFrag query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
+/// Parsed response for a GetCFrag query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetCFragResponse {
-    /// The CFrag binary data
-    pub cfrag: Binary,
-    /// Metadata about the blob
-    pub meta: BlobMeta,
-}
-
-/// Metadata for a stored blob
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct BlobMeta {
-    /// Size of the blob in bytes
-    pub size: u64,
-    /// Timestamp when the blob was created
-    pub created_at: String,
-    /// Optional content type
-    pub content_type: Option<String>,
-}
-
-/// Status of a Capsule
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum CapsuleStatus {
-    /// Capsule is pending re-encryption
-    Pending,
-    /// Capsule has been re-encrypted
-    Reencrypted,
-    /// Capsule processing failed
-    Failed,
-}
-
-/// Information about a Capsule
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct CapsuleInfo {
-    /// Capsule identifier
+    pub kfrag_id: String,
     pub capsule_id: String,
-    /// Current status of the capsule
-    pub status: CapsuleStatus,
-    /// Last update timestamp
-    pub updated_ts: String,
+    /// Raw cFrag bytes (Vec<u8> in JSON, base64 in some encodings)
+    pub cfrag: Vec<u8>,
 }
 
-/// Response for ListCapsulesByKFrag query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct ListCapsulesByKFragResponse {
-    /// List of capsules
-    pub capsules: Vec<CapsuleInfo>,
-    /// Cursor for pagination
-    pub next_start_after: Option<String>,
-}
+// ─── Validation (unchanged from ao_cwao) ─────────────────────────────────────
 
-/// Response containing cFrags for a specific secret
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct GetCFragsBySecretResponse {
-    pub cfrags: Vec<CFragEntry>,
-}
-
-/// A single cFrag entry returned from AO contract
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct CFragEntry {
-    pub cfrag_data: Binary,
-    pub holder_id: String,
-}
-
-// =====================================================================
-// AO Message Tags
-// =====================================================================
-
-/// Tags for AO messages (metadata)
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct AOMessageTags {
-    /// Application name (always "cwao" for CosmWasm AO)
-    pub app_name: String,
-    /// Action being performed
-    pub action: String,
-    /// Whether this is a read-only operation
-    pub read_only: String,
-    /// JSON-encoded input payload
-    pub input: String,
-    /// Target process ID
-    pub process_id: String,
-    /// Actor (sender) address
-    pub actor: String,
-    /// Timestamp
-    pub ts: String,
-}
-
-impl AOMessageTags {
-    /// Create tags for an execute (state-changing) message
-    pub fn new_execute(action: &str, input: &str, process_id: &str, actor: &str, ts: &str) -> Self {
-        Self {
-            app_name: "cwao".to_string(),
-            action: action.to_string(),
-            read_only: "False".to_string(),
-            input: input.to_string(),
-            process_id: process_id.to_string(),
-            actor: actor.to_string(),
-            ts: ts.to_string(),
-        }
-    }
-
-    /// Create tags for a query (read-only) message
-    pub fn new_query(action: &str, input: &str, process_id: &str, actor: &str, ts: &str) -> Self {
-        Self {
-            app_name: "cwao".to_string(),
-            action: action.to_string(),
-            read_only: "True".to_string(),
-            input: input.to_string(),
-            process_id: process_id.to_string(),
-            actor: actor.to_string(),
-            ts: ts.to_string(),
-        }
-    }
-
-    /// Check if this is a read-only operation
-    pub fn is_read_only(&self) -> bool {
-        self.read_only == "True"
-    }
-}
-
-// =====================================================================
-// Message Validation
-// =====================================================================
-
-/// Trait for validating AO messages
-pub trait ValidateMessage {
-    /// Validate the message contents
-    fn validate(&self) -> Result<(), String>;
-}
-
-impl ValidateMessage for ExecuteMsg {
-    fn validate(&self) -> Result<(), String> {
-        match self {
-            Self::DelegateKFrag { kfrag_id, kfrag } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_binary_data(kfrag, "kfrag")?;
-                Ok(())
-            }
-            Self::DelegateCapsule {
-                kfrag_id,
-                capsule_id,
-                capsule,
-            } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_capsule_id(capsule_id)?;
-                validate_binary_data(capsule, "capsule")?;
-                Ok(())
-            }
-            Self::SubmitKFrag { kfrag_id, kfrag } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_binary_data(kfrag, "kfrag")?;
-                Ok(())
-            }
-            Self::SubmitCapsule {
-                kfrag_id,
-                capsule_id,
-                capsule,
-            } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_capsule_id(capsule_id)?;
-                validate_binary_data(capsule, "capsule")?;
-                Ok(())
-            }
-            Self::Reencrypt {
-                kfrag_id,
-                capsule_id,
-            } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_capsule_id(capsule_id)?;
-                Ok(())
-            }
-        }
-    }
-}
-
-impl ValidateMessage for QueryMsg {
-    fn validate(&self) -> Result<(), String> {
-        match self {
-            Self::GetCFrag {
-                kfrag_id,
-                capsule_id,
-            } => {
-                validate_kfrag_id(kfrag_id)?;
-                validate_capsule_id(capsule_id)?;
-                Ok(())
-            }
-            Self::ListCapsulesByKFrag {
-                kfrag_id,
-                start_after,
-                limit,
-            } => {
-                validate_kfrag_id(kfrag_id)?;
-                if let Some(start_after) = start_after {
-                    validate_capsule_id(start_after)?;
-                }
-                if let Some(limit) = limit {
-                    if *limit == 0 || *limit > 100 {
-                        return Err("limit must be between 1 and 100".to_string());
-                    }
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
-// =====================================================================
-// Validation helpers
-// =====================================================================
-
-/// Maximum length for IDs (kfrag_id, capsule_id, etc.)
 pub const MAX_ID_LENGTH: usize = 128;
-
-/// Maximum size for binary data (128KB)
 pub const MAX_BINARY_SIZE: usize = 128 * 1024;
 
-/// Validate a KFrag ID
-#[allow(dead_code)]
-pub fn validate_kfrag_id(id: &str) -> Result<(), String> {
-    validate_id(id, "kfrag_id")
-}
-
-/// Validate a Capsule ID
-#[allow(dead_code)]
-pub fn validate_capsule_id(id: &str) -> Result<(), String> {
-    validate_id(id, "capsule_id")
-}
-
-/// Validate a process ID
-#[allow(dead_code)]
-pub fn validate_process_id(id: &str) -> Result<(), String> {
-    validate_id(id, "process_id")
-}
-
-/// Generic ID validation
-fn validate_id(id: &str, field_name: &str) -> Result<(), String> {
-    if id.is_empty() {
-        return Err(format!("{field_name} cannot be empty"));
-    }
+pub fn validate_id(id: &str, field: &str) -> Result<(), String> {
+    if id.is_empty() { return Err(format!("{field} cannot be empty")); }
     if id.len() > MAX_ID_LENGTH {
-        return Err(format!(
-            "{field_name} must be <= {MAX_ID_LENGTH} characters"
-        ));
+        return Err(format!("{field} must be <= {MAX_ID_LENGTH} chars"));
     }
-
-    if !id
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-    {
-        return Err(format!(
-            "{field_name} must contain only ASCII alphanumeric, underscore, or hyphen"
-        ));
+    if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return Err(format!("{field} must be ASCII alphanumeric, underscore or hyphen"));
     }
-
     Ok(())
 }
 
-/// Validate binary data
-pub fn validate_binary_data(binary: &Binary, field_name: &str) -> Result<(), String> {
-    if binary.is_empty() {
-        return Err(format!("{field_name} cannot be empty"));
-    }
-
+pub fn validate_binary(binary: &[u8], field: &str) -> Result<(), String> {
+    if binary.is_empty() { return Err(format!("{field} cannot be empty")); }
     if binary.len() > MAX_BINARY_SIZE {
-        let max_kb = MAX_BINARY_SIZE / 1024;
-        return Err(format!("{field_name} exceeds maximum size of {max_kb}KB"));
+        return Err(format!("{field} exceeds {}KB", MAX_BINARY_SIZE / 1024));
     }
-
     Ok(())
 }

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -14,31 +14,51 @@ use serde::{Deserialize, Serialize};
 pub struct Binary(#[serde(with = "base64_serde")] pub Vec<u8>);
 
 impl Binary {
-    pub fn new(bytes: Vec<u8>) -> Self { Self(bytes) }
-    pub fn as_slice(&self) -> &[u8] { &self.0 }
-    pub fn len(&self) -> usize { self.0.len() }
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
-    pub fn into_vec(self) -> Vec<u8> { self.0 }
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
 }
 impl From<Vec<u8>> for Binary {
-    fn from(bytes: Vec<u8>) -> Self { Self(bytes) }
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
 }
 impl From<&[u8]> for Binary {
-    fn from(bytes: &[u8]) -> Self { Self(bytes.to_vec()) }
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes.to_vec())
+    }
 }
 impl AsRef<[u8]> for Binary {
-    fn as_ref(&self) -> &[u8] { &self.0 }
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 mod base64_serde {
     use base64::{engine::general_purpose::STANDARD, Engine};
     use serde::{Deserialize, Deserializer, Serializer};
     pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         serializer.serialize_str(&STANDARD.encode(bytes))
     }
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         let s = String::deserialize(deserializer)?;
         STANDARD.decode(&s).map_err(serde::de::Error::custom)
     }
@@ -61,19 +81,37 @@ pub struct AOExecuteMsg {
 
 impl AOExecuteMsg {
     /// The action name (e.g. `"DelegateKFrag"`). Used internally by DataItemBuilder.
-    pub fn action(&self) -> &str { &self.action }
+    pub fn action(&self) -> &str {
+        &self.action
+    }
     /// The payload data.
-    pub fn data(&self) -> &serde_json::Value { &self.data }
+    pub fn data(&self) -> &serde_json::Value {
+        &self.data
+    }
 }
 
 impl AOExecuteMsg {
+    /// Initialize a process with a specific role.
+    /// Must be the first message sent to a newly-spawned AO process.
+    pub fn init(role: impl Into<String>) -> Self {
+        Self {
+            action: "Init".to_string(),
+            data: serde_json::json!({ "role": role.into() }),
+        }
+    }
+
     /// Delegate a kFrag to the Holder-Process.
-    pub fn delegate_kfrag(kfrag_id: impl Into<String>, kfrag: Vec<u8>) -> Self {
+    pub fn delegate_kfrag(
+        kfrag_id: impl Into<String>,
+        kfrag: Vec<u8>,
+        holder_process_id: impl Into<String>,
+    ) -> Self {
         Self {
             action: "DelegateKFrag".to_string(),
             data: serde_json::json!({
                 "kfrag_id": kfrag_id.into(),
                 "kfrag": kfrag,
+                "holder_process_id": holder_process_id.into(),
             }),
         }
     }
@@ -122,9 +160,13 @@ pub struct AOQueryMsg {
 
 impl AOQueryMsg {
     /// The action name (e.g. `"GetCFrag"`). Used internally by DataItemBuilder.
-    pub fn action(&self) -> &str { &self.action }
+    pub fn action(&self) -> &str {
+        &self.action
+    }
     /// The payload data.
-    pub fn data(&self) -> &serde_json::Value { &self.data }
+    pub fn data(&self) -> &serde_json::Value {
+        &self.data
+    }
 }
 
 impl AOQueryMsg {
@@ -176,14 +218,29 @@ pub struct AONativeResponse {
 }
 
 impl AONativeResponse {
-    pub fn success(data: serde_json::Value) -> Self {
-        Self { ok: true, data: Some(data), error: None, message_id: None }
+    pub fn success(payload: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            data: Some(payload),
+            error: None,
+            message_id: None,
+        }
     }
     pub fn success_empty() -> Self {
-        Self { ok: true, data: None, error: None, message_id: None }
+        Self {
+            ok: true,
+            data: None,
+            error: None,
+            message_id: None,
+        }
     }
     pub fn error_response(reason: impl Into<String>) -> Self {
-        Self { ok: false, data: None, error: Some(reason.into()), message_id: None }
+        Self {
+            ok: false,
+            data: None,
+            error: Some(reason.into()),
+            message_id: None,
+        }
     }
 }
 
@@ -204,18 +261,27 @@ pub const MAX_ID_LENGTH: usize = 128;
 pub const MAX_BINARY_SIZE: usize = 128 * 1024;
 
 pub fn validate_id(id: &str, field: &str) -> Result<(), String> {
-    if id.is_empty() { return Err(format!("{field} cannot be empty")); }
+    if id.is_empty() {
+        return Err(format!("{field} cannot be empty"));
+    }
     if id.len() > MAX_ID_LENGTH {
         return Err(format!("{field} must be <= {MAX_ID_LENGTH} chars"));
     }
-    if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
-        return Err(format!("{field} must be ASCII alphanumeric, underscore or hyphen"));
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(format!(
+            "{field} must be ASCII alphanumeric, underscore or hyphen"
+        ));
     }
     Ok(())
 }
 
 pub fn validate_binary(binary: &[u8], field: &str) -> Result<(), String> {
-    if binary.is_empty() { return Err(format!("{field} cannot be empty")); }
+    if binary.is_empty() {
+        return Err(format!("{field} cannot be empty"));
+    }
     if binary.len() > MAX_BINARY_SIZE {
         return Err(format!("{field} exceeds {}KB", MAX_BINARY_SIZE / 1024));
     }

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -141,7 +141,7 @@ impl AOQueryMsg {
 
     /// List Capsules associated with a kFrag (with optional pagination).
     ///
-    /// Action name: `"ListCapsulesByKFrag"` — must match the contract handler.
+    /// Action name: `"ListCapsules"` — must match the contract handler.
     /// See `ao/contracts/src/handlers.rs` for the authoritative list.
     pub fn list_capsules_by_kfrag(
         kfrag_id: impl Into<String>,
@@ -149,7 +149,7 @@ impl AOQueryMsg {
         limit: Option<u32>,
     ) -> Self {
         Self {
-            action: "ListCapsulesByKFrag".to_string(),
+            action: "ListCapsules".to_string(),
             data: serde_json::json!({
                 "kfrag_id": kfrag_id.into(),
                 "start_after": start_after,
@@ -181,6 +181,9 @@ impl AONativeResponse {
     }
     pub fn success_empty() -> Self {
         Self { ok: true, data: None, error: None, message_id: None }
+    }
+    pub fn error_response(reason: impl Into<String>) -> Self {
+        Self { ok: false, data: None, error: Some(reason.into()), message_id: None }
     }
 }
 

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -48,10 +48,22 @@ mod base64_serde {
 
 /// Execute message for state-changing operations (HyperBEAM format).
 /// Serializes as: `{ "action": "DelegateKFrag", "data": { ... } }`
+///
+/// `action` and `data` are private to prevent callers from bypassing the builder methods
+/// with arbitrary strings. Always construct via the associated builder functions
+/// (`AOExecuteMsg::delegate_kfrag`, `AOExecuteMsg::delegate_capsule`, etc.).
+/// `serde` can still deserialize the struct from wire JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AOExecuteMsg {
-    pub action: String,
-    pub data: serde_json::Value,
+    action: String,
+    data: serde_json::Value,
+}
+
+impl AOExecuteMsg {
+    /// The action name (e.g. `"DelegateKFrag"`). Used internally by DataItemBuilder.
+    pub fn action(&self) -> &str { &self.action }
+    /// The payload data.
+    pub fn data(&self) -> &serde_json::Value { &self.data }
 }
 
 impl AOExecuteMsg {
@@ -100,10 +112,19 @@ impl AOExecuteMsg {
 
 /// Query message for read-only operations (HyperBEAM format).
 /// Serializes as: `{ "action": "GetCFrag", "data": { ... } }`
+///
+/// Same privacy rationale as `AOExecuteMsg` — use the builder methods.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AOQueryMsg {
-    pub action: String,
-    pub data: serde_json::Value,
+    action: String,
+    data: serde_json::Value,
+}
+
+impl AOQueryMsg {
+    /// The action name (e.g. `"GetCFrag"`). Used internally by DataItemBuilder.
+    pub fn action(&self) -> &str { &self.action }
+    /// The payload data.
+    pub fn data(&self) -> &serde_json::Value { &self.data }
 }
 
 impl AOQueryMsg {
@@ -119,13 +140,16 @@ impl AOQueryMsg {
     }
 
     /// List Capsules associated with a kFrag (with optional pagination).
+    ///
+    /// Action name: `"ListCapsulesByKFrag"` — must match the contract handler.
+    /// See `ao/contracts/src/handlers.rs` for the authoritative list.
     pub fn list_capsules_by_kfrag(
         kfrag_id: impl Into<String>,
         start_after: Option<String>,
         limit: Option<u32>,
     ) -> Self {
         Self {
-            action: "ListCapsules".to_string(),
+            action: "ListCapsulesByKFrag".to_string(),
             data: serde_json::json!({
                 "kfrag_id": kfrag_id.into(),
                 "start_after": start_after,

--- a/client/src/adapter/external/ao/mod.rs
+++ b/client/src/adapter/external/ao/mod.rs
@@ -1,15 +1,14 @@
-//! AO Network client module
+//! AO Network client module (HyperBEAM-native)
 //!
-//! Provides production implementation of AOClient trait
-//! for AO Network communication.
+//! Replaces `ao_cwao/` which used CosmWasm-style messages on the legacy AO testnet.
+//! This module targets HyperBEAM (~wasm64@1.0) with AO-native message format.
 //!
 //! ## Module Structure
-//!
-//! - `client` - AOClient trait definition
-//! - `config` - AO Network connection configuration
-//! - `message` - Message types for AO communication
+//! - `client` - AOClient trait (updated for HyperBEAM message types)
+//! - `config` - AO Network connection config (HyperBEAM endpoints)
+//! - `message` - AO-native message types (AOExecuteMsg, AOQueryMsg, AONativeResponse)
 //! - `data_item` - ANS-104 DataItem builder and signer (production feature)
-//! - `production_client` - Production AOClient implementation (production feature)
+//! - `production_client` - ProductionAOClient impl (production feature)
 
 mod client;
 mod config;
@@ -24,9 +23,8 @@ pub use config::AOConfig;
 #[cfg(feature = "production-ao")]
 pub use data_item::{ArweaveJWK, DataItemBuilder, DataItemSigner};
 pub use message::{
-    AOAttribute, AOEvent, AOMessageTags, AOResponse, Binary, BlobMeta, CFragEntry, CapsuleInfo,
-    CapsuleStatus, ExecuteMsg, GetCFragResponse, GetCFragsBySecretResponse,
-    ListCapsulesByKFragResponse, QueryMsg, ValidateMessage, MAX_BINARY_SIZE, MAX_ID_LENGTH,
+    AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
+    MAX_BINARY_SIZE, MAX_ID_LENGTH, validate_id, validate_binary,
 };
 #[cfg(feature = "production-ao")]
 pub use production_client::ProductionAOClient;

--- a/client/src/adapter/external/ao/mod.rs
+++ b/client/src/adapter/external/ao/mod.rs
@@ -23,8 +23,8 @@ pub use config::AOConfig;
 #[cfg(feature = "production-ao")]
 pub use data_item::{ArweaveJWK, DataItemBuilder, DataItemSigner};
 pub use message::{
-    AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
-    MAX_BINARY_SIZE, MAX_ID_LENGTH, validate_id, validate_binary,
+    validate_binary, validate_id, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary,
+    GetCFragResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };
 #[cfg(feature = "production-ao")]
 pub use production_client::ProductionAOClient;

--- a/client/src/adapter/external/ao/production_client.rs
+++ b/client/src/adapter/external/ao/production_client.rs
@@ -117,13 +117,16 @@ impl ProductionAOClient {
     }
 
     /// Parse AO-native response from CU result.
+    ///
     /// The new contract returns `{ "ok": bool, "data": {...}, "error": "..." }`.
+    /// `ok: false` or any unparseable Output.data is treated as an error —
+    /// never silently promoted to success.
     fn parse_cu_result(
         process_id: &str,
         json: &serde_json::Value,
         message_id: Option<String>,
     ) -> Result<AONativeResponse, AOCommunicationError> {
-        // First check for AO-level error (process not found, etc.)
+        // AO-level error (process not found, scheduler rejection, etc.)
         if let Some(error) = json.get("Error") {
             if !error.is_null() {
                 return Err(AOCommunicationError::ExecutionError {
@@ -133,24 +136,38 @@ impl ProductionAOClient {
             }
         }
 
-        // Try to extract Output.data as AO-native JSON response
+        // Extract Output.data (contract response JSON string)
         let output = json.get("Output");
         if let Some(obj) = output {
-            // AO Output.data contains our JSON response string
             if let Some(data_str) = obj.get("data").and_then(|d| d.as_str()) {
-                // Try to parse as AONativeResponse
-                if let Ok(mut native_resp) = serde_json::from_str::<AONativeResponse>(data_str) {
-                    native_resp.message_id = message_id;
-                    return Ok(native_resp);
+                // Must parse as AONativeResponse; if the contract returned well-formed JSON,
+                // this always succeeds. Non-JSON output is a contract bug → surface as error.
+                let mut native_resp =
+                    serde_json::from_str::<AONativeResponse>(data_str).map_err(|e| {
+                        AOCommunicationError::DeserializationError {
+                            details: format!(
+                                "Contract Output.data is not a valid AONativeResponse: {e}; \
+                                 raw output: {data_str}"
+                            ),
+                        }
+                    })?;
+
+                // ok: false means the contract reported a logical error
+                if !native_resp.ok {
+                    let reason = native_resp
+                        .error
+                        .unwrap_or_else(|| "contract returned ok:false".to_string());
+                    return Err(AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: reason,
+                    });
                 }
-                // Fallback: treat as raw data
-                return Ok(AONativeResponse {
-                    ok: true,
-                    data: Some(serde_json::Value::String(data_str.to_string())),
-                    error: None,
-                    message_id,
-                });
+
+                native_resp.message_id = message_id;
+                return Ok(native_resp);
             }
+
+            // Output is a JSON object/array (not a string) — wrap it
             if obj.is_object() || obj.is_array() {
                 return Ok(AONativeResponse {
                     ok: true,
@@ -161,6 +178,7 @@ impl ProductionAOClient {
             }
         }
 
+        // No Output block — treat as empty success (e.g. MU acknowledgment only)
         Ok(AONativeResponse { ok: true, data: None, error: None, message_id })
     }
 

--- a/client/src/adapter/external/ao/production_client.rs
+++ b/client/src/adapter/external/ao/production_client.rs
@@ -30,11 +30,16 @@ impl ProductionAOClient {
             .map_err(|e| AOCommunicationError::ConnectionError {
                 details: format!("Failed to create HTTP client: {e}"),
             })?;
-        Ok(Self { config, http_client, signer })
+        Ok(Self {
+            config,
+            http_client,
+            signer,
+        })
     }
 
     async fn post_to_mu(&self, item_bytes: &[u8]) -> Result<String, AOCommunicationError> {
-        let response = self.http_client
+        let response = self
+            .http_client
             .post(self.config.mu_url())
             .header("Content-Type", "application/octet-stream")
             .body(item_bytes.to_vec())
@@ -50,10 +55,13 @@ impl ProductionAOClient {
                 details: format!("MU returned {status}: {body}"),
             });
         }
-        let body: serde_json::Value = response.json().await
-            .map_err(|e| AOCommunicationError::DeserializationError {
-                details: format!("MU response parse: {e}"),
-            })?;
+        let body: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|e| AOCommunicationError::DeserializationError {
+                    details: format!("MU response parse: {e}"),
+                })?;
         body["id"].as_str().map(str::to_string).ok_or_else(|| {
             AOCommunicationError::DeserializationError {
                 details: "MU response missing 'id'".to_string(),
@@ -68,9 +76,15 @@ impl ProductionAOClient {
     ) -> Result<serde_json::Value, AOCommunicationError> {
         let url = format!(
             "{}/result/{}?process-id={}&no-busy",
-            self.config.cu_url(), message_id, process_id
+            self.config.cu_url(),
+            message_id,
+            process_id
         );
-        let response = self.http_client.get(&url).send().await
+        let response = self
+            .http_client
+            .get(&url)
+            .send()
+            .await
             .map_err(|e| Self::map_reqwest_error(&e, "CU result", self.config.timeout_ms()))?;
 
         let status = response.status();
@@ -85,9 +99,12 @@ impl ProductionAOClient {
                 details: format!("CU returned {status}"),
             });
         }
-        response.json().await.map_err(|e| AOCommunicationError::DeserializationError {
-            details: format!("CU result parse: {e}"),
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| AOCommunicationError::DeserializationError {
+                details: format!("CU result parse: {e}"),
+            })
     }
 
     async fn post_cu_dry_run(
@@ -96,7 +113,12 @@ impl ProductionAOClient {
         body: serde_json::Value,
     ) -> Result<serde_json::Value, AOCommunicationError> {
         let url = format!("{}/dry-run?process-id={}", self.config.cu_url(), process_id);
-        let response = self.http_client.post(&url).json(&body).send().await
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
             .map_err(|e| Self::map_reqwest_error(&e, "CU dry-run", self.config.timeout_ms()))?;
 
         let status = response.status();
@@ -111,9 +133,12 @@ impl ProductionAOClient {
                 details: format!("CU dry-run returned {status}"),
             });
         }
-        response.json().await.map_err(|e| AOCommunicationError::DeserializationError {
-            details: format!("CU dry-run parse: {e}"),
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| AOCommunicationError::DeserializationError {
+                details: format!("CU dry-run parse: {e}"),
+            })
     }
 
     /// Parse AO-native response from CU result.
@@ -179,7 +204,12 @@ impl ProductionAOClient {
         }
 
         // No Output block — treat as empty success (e.g. MU acknowledgment only)
-        Ok(AONativeResponse { ok: true, data: None, error: None, message_id })
+        Ok(AONativeResponse {
+            ok: true,
+            data: None,
+            error: None,
+            message_id,
+        })
     }
 
     fn parse_cu_dryrun_data(
@@ -198,8 +228,12 @@ impl ProductionAOClient {
         if let Some(obj) = json.get("Output") {
             if let Some(data_str) = obj.get("data").and_then(|d| d.as_str()) {
                 // Try base64 decode, fallback to raw bytes
-                use base64::{engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}, Engine};
-                return match STANDARD.decode(data_str)
+                use base64::{
+                    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+                    Engine,
+                };
+                return match STANDARD
+                    .decode(data_str)
                     .or_else(|_| URL_SAFE_NO_PAD.decode(data_str))
                 {
                     Ok(decoded) => Ok(Binary::from(decoded)),
@@ -219,11 +253,20 @@ impl ProductionAOClient {
         Ok(Binary::from(Vec::new()))
     }
 
-    fn map_reqwest_error(err: &reqwest::Error, operation: &str, timeout_ms: u64) -> AOCommunicationError {
+    fn map_reqwest_error(
+        err: &reqwest::Error,
+        operation: &str,
+        timeout_ms: u64,
+    ) -> AOCommunicationError {
         if err.is_timeout() {
-            AOCommunicationError::Timeout { operation: operation.to_string(), timeout_ms }
+            AOCommunicationError::Timeout {
+                operation: operation.to_string(),
+                timeout_ms,
+            }
         } else if err.is_connect() {
-            AOCommunicationError::ConnectionError { details: format!("{operation} connect: {err}") }
+            AOCommunicationError::ConnectionError {
+                details: format!("{operation} connect: {err}"),
+            }
         } else {
             AOCommunicationError::ExecutionError {
                 process_id: String::new(),

--- a/client/src/adapter/external/ao_cwao/client.rs
+++ b/client/src/adapter/external/ao_cwao/client.rs
@@ -1,0 +1,56 @@
+//! AO Network client trait
+//!
+//! This module provides the AOClient trait for abstracting AO Network communication.
+
+use async_trait::async_trait;
+
+use super::message::{AOResponse, Binary, ExecuteMsg, QueryMsg};
+use crate::adapter::errors::AOCommunicationError;
+
+/// AOClient trait for AO Network communication
+///
+/// This trait abstracts the communication with AO Network processes,
+/// enabling dependency injection and easy mocking for tests.
+#[async_trait]
+pub trait AOClient: Send + Sync {
+    /// Execute a state-changing message to an AO Process
+    ///
+    /// # Arguments
+    /// * `process_id` - The AO Process ID to send the message to
+    /// * `msg` - The execute message to send
+    ///
+    /// # Returns
+    /// * `Ok(AOResponse)` - The response from the process
+    /// * `Err(AOCommunicationError)` - If the execution fails
+    async fn execute(
+        &self,
+        process_id: &str,
+        msg: ExecuteMsg,
+    ) -> Result<AOResponse, AOCommunicationError>;
+
+    /// Query an AO Process (read-only, via dry_run)
+    ///
+    /// # Arguments
+    /// * `process_id` - The AO Process ID to query
+    /// * `msg` - The query message to send
+    ///
+    /// # Returns
+    /// * `Ok(Binary)` - The query result as binary data
+    /// * `Err(AOCommunicationError)` - If the query fails
+    async fn query(&self, process_id: &str, msg: QueryMsg) -> Result<Binary, AOCommunicationError>;
+
+    /// Dry-run execution (read-only state inspection)
+    ///
+    /// # Arguments
+    /// * `process_id` - The AO Process ID to dry-run against
+    /// * `msg` - The execute message to simulate
+    ///
+    /// # Returns
+    /// * `Ok(AOResponse)` - The simulated response
+    /// * `Err(AOCommunicationError)` - If the dry-run fails
+    async fn dry_run(
+        &self,
+        process_id: &str,
+        msg: ExecuteMsg,
+    ) -> Result<AOResponse, AOCommunicationError>;
+}

--- a/client/src/adapter/external/ao_cwao/config.rs
+++ b/client/src/adapter/external/ao_cwao/config.rs
@@ -1,22 +1,14 @@
-//! AO Network configuration for HyperBEAM nodes.
-//!
-//! Default URLs updated to HyperBEAM-compatible endpoints.
-//! Set `AO_MU_URL` / `AO_CU_URL` env vars to override.
-
 #[cfg(not(target_arch = "wasm32"))]
 use std::env;
 
 use crate::adapter::errors::AOCommunicationError;
 
-/// TODO: Replace with confirmed production HyperBEAM MU endpoint.
-/// Candidates: https://mu.ao-testnet.xyz still works for ao-legacy;
-/// HyperBEAM-native MU is TBD pending public node announcement.
 const DEFAULT_MU_URL: &str = "https://mu.ao-testnet.xyz";
 const DEFAULT_CU_URL: &str = "https://cu.ao-testnet.xyz";
 const DEFAULT_GATEWAY_URL: &str = "https://arweave.net";
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
-/// AO Network connection configuration.
+/// AO Network connection configuration
 #[derive(Debug, Clone)]
 pub struct AOConfig {
     mu_url: String,
@@ -42,6 +34,7 @@ impl AOConfig {
                 details: "CU URL must not be empty".to_string(),
             });
         }
+
         Ok(Self {
             mu_url: mu_url.to_string(),
             cu_url: cu_url.to_string(),
@@ -50,10 +43,21 @@ impl AOConfig {
         })
     }
 
-    pub fn mu_url(&self) -> &str { &self.mu_url }
-    pub fn cu_url(&self) -> &str { &self.cu_url }
-    pub fn gateway_url(&self) -> &str { &self.gateway_url }
-    pub fn timeout_ms(&self) -> u64 { self.timeout_ms }
+    pub fn mu_url(&self) -> &str {
+        &self.mu_url
+    }
+
+    pub fn cu_url(&self) -> &str {
+        &self.cu_url
+    }
+
+    pub fn gateway_url(&self) -> &str {
+        &self.gateway_url
+    }
+
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_env() -> Result<Self, AOCommunicationError> {
@@ -65,6 +69,7 @@ impl AOConfig {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_TIMEOUT_MS);
+
         Self::new(&mu_url, &cu_url, &gateway_url, timeout_ms)
     }
 }

--- a/client/src/adapter/external/ao_cwao/data_item.rs
+++ b/client/src/adapter/external/ao_cwao/data_item.rs
@@ -1,0 +1,510 @@
+#![allow(clippy::disallowed_names)]
+
+use std::fmt;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use rand::rngs::OsRng;
+use rsa::pss::SigningKey;
+use rsa::signature::RandomizedSigner;
+use rsa::signature::SignatureEncoding;
+use rsa::{BigUint, RsaPrivateKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256, Sha384};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::message::{ExecuteMsg, QueryMsg};
+use crate::adapter::errors::AOCommunicationError;
+
+// AO protocol constants
+const DATA_PROTOCOL: &str = "ao";
+const VARIANT: &str = "ao.TN.1";
+const MESSAGE_TYPE: &str = "Message";
+const SDK: &str = "ao";
+
+/// Tag attached to a DataItem (name-value pair)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataItemTag {
+    pub name: String,
+    pub value: String,
+}
+
+impl DataItemTag {
+    pub fn new(name: &str, value: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+}
+
+/// Unsigned DataItem ready for signing (ANS-104 format)
+#[derive(Debug, Clone)]
+pub struct UnsignedDataItem {
+    pub target: Vec<u8>,
+    pub anchor: Vec<u8>,
+    pub tags: Vec<DataItemTag>,
+    pub data: Vec<u8>,
+}
+
+/// Builds AO-compatible DataItems from ExecuteMsg/QueryMsg
+pub struct DataItemBuilder;
+
+impl DataItemBuilder {
+    /// Build an unsigned DataItem from an ExecuteMsg for MU submission
+    pub fn build_execute(
+        target: &str,
+        msg: &ExecuteMsg,
+    ) -> Result<UnsignedDataItem, AOCommunicationError> {
+        let action = Self::execute_msg_action(msg);
+        let data =
+            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize ExecuteMsg: {e}"),
+            })?;
+
+        let tags = Self::ao_tags(target, &action);
+
+        let target_bytes =
+            URL_SAFE_NO_PAD
+                .decode(target)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url target: {e}"),
+                })?;
+        if target_bytes.len() != 32 {
+            return Err(AOCommunicationError::ValidationError {
+                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
+            });
+        }
+
+        Ok(UnsignedDataItem {
+            target: target_bytes,
+            anchor: Vec::new(),
+            tags,
+            data,
+        })
+    }
+
+    /// Build a JSON body for CU dry-run API (ExecuteMsg)
+    pub fn build_dry_run_body(
+        target: &str,
+        msg: &ExecuteMsg,
+    ) -> Result<serde_json::Value, AOCommunicationError> {
+        let action = Self::execute_msg_action(msg);
+        let data =
+            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize ExecuteMsg: {e}"),
+            })?;
+
+        Ok(Self::dry_run_json(target, &action, &data))
+    }
+
+    /// Build a JSON body for CU dry-run API (QueryMsg)
+    pub fn build_query_body(
+        target: &str,
+        msg: &QueryMsg,
+    ) -> Result<serde_json::Value, AOCommunicationError> {
+        let action = Self::query_msg_action(msg);
+        let data =
+            serde_json::to_string(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize QueryMsg: {e}"),
+            })?;
+
+        Ok(Self::dry_run_json(target, &action, &data))
+    }
+
+    fn execute_msg_action(msg: &ExecuteMsg) -> String {
+        match msg {
+            ExecuteMsg::DelegateKFrag { .. } => "DelegateKFrag".to_string(),
+            ExecuteMsg::DelegateCapsule { .. } => "DelegateCapsule".to_string(),
+            ExecuteMsg::SubmitKFrag { .. } => "SubmitKFrag".to_string(),
+            ExecuteMsg::SubmitCapsule { .. } => "SubmitCapsule".to_string(),
+            ExecuteMsg::Reencrypt { .. } => "Reencrypt".to_string(),
+        }
+    }
+
+    fn query_msg_action(msg: &QueryMsg) -> String {
+        match msg {
+            QueryMsg::GetCFrag { .. } => "GetCFrag".to_string(),
+            QueryMsg::ListCapsulesByKFrag { .. } => "ListCapsulesByKFrag".to_string(),
+        }
+    }
+
+    /// Build an unsigned DataItem with Read-Only tag for query via MU
+    pub fn build_read_only(
+        target: &str,
+        msg: &QueryMsg,
+    ) -> Result<UnsignedDataItem, AOCommunicationError> {
+        let action = Self::query_msg_action(msg);
+        let data =
+            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize QueryMsg: {e}"),
+            })?;
+
+        let mut tags = Self::ao_tags(target, &action);
+        tags.push(DataItemTag::new("Read-Only", "True"));
+
+        let target_bytes =
+            URL_SAFE_NO_PAD
+                .decode(target)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url target: {e}"),
+                })?;
+        if target_bytes.len() != 32 {
+            return Err(AOCommunicationError::ValidationError {
+                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
+            });
+        }
+
+        Ok(UnsignedDataItem {
+            target: target_bytes,
+            anchor: Vec::new(),
+            tags,
+            data,
+        })
+    }
+
+    /// Build an unsigned DataItem with Read-Only tag for dry-run via MU
+    pub fn build_dry_run(
+        target: &str,
+        msg: &ExecuteMsg,
+    ) -> Result<UnsignedDataItem, AOCommunicationError> {
+        let action = Self::execute_msg_action(msg);
+        let data =
+            serde_json::to_vec(msg).map_err(|e| AOCommunicationError::SerializationError {
+                details: format!("Failed to serialize ExecuteMsg: {e}"),
+            })?;
+
+        let mut tags = Self::ao_tags(target, &action);
+        tags.push(DataItemTag::new("Read-Only", "True"));
+
+        let target_bytes =
+            URL_SAFE_NO_PAD
+                .decode(target)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url target: {e}"),
+                })?;
+        if target_bytes.len() != 32 {
+            return Err(AOCommunicationError::ValidationError {
+                details: format!("Target must be 32 bytes (got {})", target_bytes.len()),
+            });
+        }
+
+        Ok(UnsignedDataItem {
+            target: target_bytes,
+            anchor: Vec::new(),
+            tags,
+            data,
+        })
+    }
+
+    fn ao_tags(target: &str, action: &str) -> Vec<DataItemTag> {
+        vec![
+            DataItemTag::new("Data-Protocol", DATA_PROTOCOL),
+            DataItemTag::new("Variant", VARIANT),
+            DataItemTag::new("Type", MESSAGE_TYPE),
+            DataItemTag::new("SDK", SDK),
+            DataItemTag::new("Action", action),
+            DataItemTag::new("Target", target),
+        ]
+    }
+
+    fn dry_run_json(target: &str, action: &str, data: &str) -> serde_json::Value {
+        #[derive(Serialize)]
+        struct DryRunTag {
+            name: String,
+            value: String,
+        }
+
+        let tags: Vec<DryRunTag> = vec![
+            DryRunTag {
+                name: "Data-Protocol".to_string(),
+                value: DATA_PROTOCOL.to_string(),
+            },
+            DryRunTag {
+                name: "Variant".to_string(),
+                value: VARIANT.to_string(),
+            },
+            DryRunTag {
+                name: "Type".to_string(),
+                value: MESSAGE_TYPE.to_string(),
+            },
+            DryRunTag {
+                name: "SDK".to_string(),
+                value: SDK.to_string(),
+            },
+            DryRunTag {
+                name: "Action".to_string(),
+                value: action.to_string(),
+            },
+        ];
+
+        serde_json::json!({
+            "Target": target,
+            "Tags": tags,
+            "Data": data,
+        })
+    }
+}
+
+/// Arweave JWK (JSON Web Key) for RSA signing
+///
+/// Secret RSA components (d, p, q, dp, dq, qi) are zeroized on drop
+/// to prevent private key material from lingering in memory.
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct ArweaveJWK {
+    #[zeroize(skip)]
+    pub kty: String,
+    #[zeroize(skip)]
+    pub n: String,
+    #[zeroize(skip)]
+    pub e: String,
+    #[serde(default)]
+    pub d: String,
+    #[serde(default)]
+    pub p: String,
+    #[serde(default)]
+    pub q: String,
+    #[serde(default)]
+    pub dp: String,
+    #[serde(default)]
+    pub dq: String,
+    #[serde(default)]
+    pub qi: String,
+}
+
+impl fmt::Debug for ArweaveJWK {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ArweaveJWK")
+            .field("kty", &self.kty)
+            .field("n", &format!("[{} chars]", self.n.len()))
+            .field("e", &self.e)
+            .field("d", &"[REDACTED]")
+            .field("p", &"[REDACTED]")
+            .field("q", &"[REDACTED]")
+            .field("dp", &"[REDACTED]")
+            .field("dq", &"[REDACTED]")
+            .field("qi", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ANS-104 signature type for RSA-256
+const SIG_TYPE_RSA256: u16 = 1;
+const RSA_SIG_LENGTH: usize = 512;
+const RSA_OWNER_LENGTH: usize = 512;
+
+/// Signs UnsignedDataItems with an Arweave RSA key
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct DataItemSigner {
+    #[zeroize(skip)]
+    signing_key: SigningKey<Sha256>,
+    owner_bytes: Vec<u8>,
+}
+
+impl DataItemSigner {
+    pub fn new(jwk: &ArweaveJWK) -> Result<Self, AOCommunicationError> {
+        if jwk.kty != "RSA" {
+            return Err(AOCommunicationError::ValidationError {
+                details: "JWK kty must be RSA".to_string(),
+            });
+        }
+        if jwk.n.is_empty() || jwk.e.is_empty() || jwk.d.is_empty() {
+            return Err(AOCommunicationError::ValidationError {
+                details: "JWK missing required RSA fields".to_string(),
+            });
+        }
+
+        let decode = |field: &str, name: &str| -> Result<BigUint, AOCommunicationError> {
+            let bytes = URL_SAFE_NO_PAD.decode(field).map_err(|e| {
+                AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url in JWK {name}: {e}"),
+                }
+            })?;
+            Ok(BigUint::from_bytes_be(&bytes))
+        };
+
+        let n = decode(&jwk.n, "n")?;
+        let e = decode(&jwk.e, "e")?;
+        let d = decode(&jwk.d, "d")?;
+
+        let mut primes = Vec::new();
+        if !jwk.p.is_empty() && !jwk.q.is_empty() {
+            primes.push(decode(&jwk.p, "p")?);
+            primes.push(decode(&jwk.q, "q")?);
+        }
+
+        let private_key = RsaPrivateKey::from_components(n, e, d, primes).map_err(|e| {
+            AOCommunicationError::ValidationError {
+                details: format!("Invalid RSA key: {e}"),
+            }
+        })?;
+
+        let owner_bytes =
+            URL_SAFE_NO_PAD
+                .decode(&jwk.n)
+                .map_err(|e| AOCommunicationError::ValidationError {
+                    details: format!("Invalid base64url in JWK n: {e}"),
+                })?;
+        if owner_bytes.len() != RSA_OWNER_LENGTH {
+            return Err(AOCommunicationError::ValidationError {
+                details: format!(
+                    "Invalid RSA modulus length: expected {} bytes, got {}",
+                    RSA_OWNER_LENGTH,
+                    owner_bytes.len()
+                ),
+            });
+        }
+
+        let signing_key = SigningKey::<Sha256>::new(private_key);
+
+        Ok(Self {
+            signing_key,
+            owner_bytes,
+        })
+    }
+
+    /// Sign a DataItem and return complete ANS-104 signed bytes
+    pub fn sign(&self, item: &UnsignedDataItem) -> Result<Vec<u8>, AOCommunicationError> {
+        let deep_hash = self.build_deep_hash(item);
+        let signature = self.signing_key.sign_with_rng(&mut OsRng, &deep_hash);
+        let sig_bytes = signature.to_bytes();
+
+        let mut result = Vec::new();
+
+        // Signature type (2 bytes, little-endian)
+        result.extend_from_slice(&SIG_TYPE_RSA256.to_le_bytes());
+
+        // Signature (512 bytes, zero-padded)
+        let mut sig_padded = vec![0u8; RSA_SIG_LENGTH];
+        let sig_vec = sig_bytes.to_vec();
+        let start = RSA_SIG_LENGTH.saturating_sub(sig_vec.len());
+        sig_padded[start..].copy_from_slice(&sig_vec);
+        result.extend_from_slice(&sig_padded);
+
+        // Owner (512 bytes, zero-padded)
+        let mut owner_padded = vec![0u8; RSA_OWNER_LENGTH];
+        let start = RSA_OWNER_LENGTH.saturating_sub(self.owner_bytes.len());
+        owner_padded[start..].copy_from_slice(&self.owner_bytes);
+        result.extend_from_slice(&owner_padded);
+
+        // Target
+        if item.target.is_empty() {
+            result.push(0);
+        } else {
+            result.push(1);
+            result.extend_from_slice(&item.target);
+        }
+
+        // Anchor
+        if item.anchor.is_empty() {
+            result.push(0);
+        } else {
+            result.push(1);
+            result.extend_from_slice(&item.anchor);
+        }
+
+        // Tags
+        let tags_bytes = self.serialize_avro_tags(&item.tags);
+        let num_tags = item.tags.len() as u64;
+        result.extend_from_slice(&num_tags.to_le_bytes());
+        result.extend_from_slice(&(tags_bytes.len() as u64).to_le_bytes());
+        result.extend_from_slice(&tags_bytes);
+
+        // Data
+        result.extend_from_slice(&item.data);
+
+        Ok(result)
+    }
+
+    /// Owner address: base64url(SHA-256(owner_public_key_bytes))
+    pub fn owner_address(&self) -> String {
+        let hash = Sha256::digest(&self.owner_bytes);
+        URL_SAFE_NO_PAD.encode(hash)
+    }
+
+    /// ANS-104 deep hash: SHA-384-based recursive tree hash
+    fn build_deep_hash(&self, item: &UnsignedDataItem) -> Vec<u8> {
+        let tags_bytes = self.serialize_avro_tags(&item.tags);
+        let sig_type_str = SIG_TYPE_RSA256.to_string();
+
+        let parts: Vec<&[u8]> = vec![
+            b"dataitem",
+            b"1",
+            sig_type_str.as_bytes(),
+            &self.owner_bytes,
+            &item.target,
+            &item.anchor,
+            &tags_bytes,
+            &item.data,
+        ];
+
+        let hashed_parts: Vec<[u8; 48]> = parts.iter().map(|p| Self::deep_hash_blob(p)).collect();
+        Self::deep_hash_list(&hashed_parts).to_vec()
+    }
+
+    fn deep_hash_blob(data: &[u8]) -> [u8; 48] {
+        let mut tag = Vec::new();
+        tag.extend_from_slice(b"blob");
+        tag.extend_from_slice(data.len().to_string().as_bytes());
+
+        let tag_hash = Sha384::digest(&tag);
+        let data_hash = Sha384::digest(data);
+
+        let mut combined = Vec::with_capacity(96);
+        combined.extend_from_slice(&tag_hash);
+        combined.extend_from_slice(&data_hash);
+        Sha384::digest(&combined).into()
+    }
+
+    fn deep_hash_list(items: &[[u8; 48]]) -> [u8; 48] {
+        let mut tag = Vec::new();
+        tag.extend_from_slice(b"list");
+        tag.extend_from_slice(items.len().to_string().as_bytes());
+
+        let mut acc: [u8; 48] = Sha384::digest(&tag).into();
+
+        for item in items {
+            let mut combined = Vec::with_capacity(96);
+            combined.extend_from_slice(&acc);
+            combined.extend_from_slice(item);
+            acc = Sha384::digest(&combined).into();
+        }
+
+        acc
+    }
+
+    fn serialize_avro_tags(&self, tags: &[DataItemTag]) -> Vec<u8> {
+        if tags.is_empty() {
+            return Vec::new();
+        }
+
+        let mut buf = Vec::new();
+        #[allow(clippy::cast_possible_wrap)]
+        Self::avro_encode_long(&mut buf, tags.len() as i64);
+        for tag in tags {
+            let name_bytes = tag.name.as_bytes();
+            let value_bytes = tag.value.as_bytes();
+            #[allow(clippy::cast_possible_wrap)]
+            Self::avro_encode_long(&mut buf, name_bytes.len() as i64);
+            buf.extend_from_slice(name_bytes);
+            #[allow(clippy::cast_possible_wrap)]
+            Self::avro_encode_long(&mut buf, value_bytes.len() as i64);
+            buf.extend_from_slice(value_bytes);
+        }
+        Self::avro_encode_long(&mut buf, 0);
+        buf
+    }
+
+    fn avro_encode_long(buf: &mut Vec<u8>, val: i64) {
+        #[allow(clippy::cast_sign_loss)]
+        let mut v = ((val << 1) ^ (val >> 63)) as u64;
+        loop {
+            if v & !0x7F == 0 {
+                buf.push(v as u8);
+                break;
+            }
+            buf.push((v as u8 & 0x7F) | 0x80);
+            v >>= 7;
+        }
+    }
+}

--- a/client/src/adapter/external/ao_cwao/message.rs
+++ b/client/src/adapter/external/ao_cwao/message.rs
@@ -1,0 +1,527 @@
+//! AO Message types for client-side communication
+//!
+//! This module defines message types for communicating with AO Network processes.
+//! Types are duplicated from `ao/contracts/src/msg.rs` for client independence.
+
+use serde::{Deserialize, Serialize};
+
+// =====================================================================
+// Binary wrapper type
+// =====================================================================
+
+/// Binary data wrapper for serialization
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct Binary(#[serde(with = "base64_serde")] pub Vec<u8>);
+
+impl Binary {
+    /// Create a new Binary from bytes
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Get the underlying bytes as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Get the length of the binary data
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the binary data is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consume and return the underlying Vec
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for Binary {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<&[u8]> for Binary {
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes.to_vec())
+    }
+}
+
+impl AsRef<[u8]> for Binary {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+mod base64_serde {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        STANDARD.decode(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// =====================================================================
+// Execute Messages (state-changing operations)
+// =====================================================================
+
+/// Execute messages for state-changing operations on AO processes
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ExecuteMsg {
+    /// Delegate a KFrag to the Owner-Process
+    DelegateKFrag { kfrag_id: String, kfrag: Binary },
+
+    /// Delegate a Capsule along with its associated KFrag
+    DelegateCapsule {
+        kfrag_id: String,
+        capsule_id: String,
+        capsule: Binary,
+    },
+
+    /// Submit a KFrag to a Holder-Process
+    SubmitKFrag { kfrag_id: String, kfrag: Binary },
+
+    /// Submit a Capsule to a Holder-Process
+    SubmitCapsule {
+        kfrag_id: String,
+        capsule_id: String,
+        capsule: Binary,
+    },
+
+    /// Request re-encryption of a Capsule
+    Reencrypt {
+        kfrag_id: String,
+        capsule_id: String,
+    },
+}
+
+// =====================================================================
+// Query Messages (read-only operations)
+// =====================================================================
+
+/// Query messages for read-only operations on AO processes
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum QueryMsg {
+    /// Get a CFrag for a specific KFrag and Capsule
+    GetCFrag {
+        kfrag_id: String,
+        capsule_id: String,
+    },
+
+    /// List all Capsules associated with a KFrag
+    ListCapsulesByKFrag {
+        kfrag_id: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+}
+
+// =====================================================================
+// Response types
+// =====================================================================
+
+/// Response from AO Process execution
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AOResponse {
+    /// Whether the execution succeeded
+    pub success: bool,
+    /// Response data (if any)
+    pub data: Option<Binary>,
+    /// Events emitted during execution
+    pub events: Vec<AOEvent>,
+    /// MU-returned message ID for AO Link verification
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+}
+
+impl AOResponse {
+    /// Create a successful response with no data
+    pub fn success() -> Self {
+        Self {
+            success: true,
+            data: None,
+            events: Vec::new(),
+            message_id: None,
+        }
+    }
+
+    /// Create a successful response with data
+    pub fn success_with_data(value: Binary) -> Self {
+        Self {
+            success: true,
+            data: Some(value),
+            events: Vec::new(),
+            message_id: None,
+        }
+    }
+
+    /// Create a successful response with events
+    pub fn success_with_events(events: Vec<AOEvent>) -> Self {
+        Self {
+            success: true,
+            data: None,
+            events,
+            message_id: None,
+        }
+    }
+
+    /// Add an event to the response
+    pub fn add_event(&mut self, event: AOEvent) {
+        self.events.push(event);
+    }
+}
+
+/// Event emitted during AO execution
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AOEvent {
+    /// Type of the event
+    pub event_type: String,
+    /// Attributes associated with the event
+    pub attributes: Vec<AOAttribute>,
+}
+
+impl AOEvent {
+    /// Create a new event
+    pub fn new(event_type: &str) -> Self {
+        Self {
+            event_type: event_type.to_string(),
+            attributes: Vec::new(),
+        }
+    }
+
+    /// Add an attribute to the event
+    pub fn add_attribute(&mut self, key: &str, value: &str) {
+        self.attributes.push(AOAttribute {
+            key: key.to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    /// Create an event with attributes
+    pub fn with_attributes(event_type: &str, attributes: Vec<(&str, &str)>) -> Self {
+        Self {
+            event_type: event_type.to_string(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| AOAttribute {
+                    key: k.to_string(),
+                    value: v.to_string(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Attribute of an AO event
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AOAttribute {
+    /// Attribute key
+    pub key: String,
+    /// Attribute value
+    pub value: String,
+}
+
+/// Response for GetCFrag query
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct GetCFragResponse {
+    /// The CFrag binary data
+    pub cfrag: Binary,
+    /// Metadata about the blob
+    pub meta: BlobMeta,
+}
+
+/// Metadata for a stored blob
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BlobMeta {
+    /// Size of the blob in bytes
+    pub size: u64,
+    /// Timestamp when the blob was created
+    pub created_at: String,
+    /// Optional content type
+    pub content_type: Option<String>,
+}
+
+/// Status of a Capsule
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CapsuleStatus {
+    /// Capsule is pending re-encryption
+    Pending,
+    /// Capsule has been re-encrypted
+    Reencrypted,
+    /// Capsule processing failed
+    Failed,
+}
+
+/// Information about a Capsule
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CapsuleInfo {
+    /// Capsule identifier
+    pub capsule_id: String,
+    /// Current status of the capsule
+    pub status: CapsuleStatus,
+    /// Last update timestamp
+    pub updated_ts: String,
+}
+
+/// Response for ListCapsulesByKFrag query
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ListCapsulesByKFragResponse {
+    /// List of capsules
+    pub capsules: Vec<CapsuleInfo>,
+    /// Cursor for pagination
+    pub next_start_after: Option<String>,
+}
+
+/// Response containing cFrags for a specific secret
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct GetCFragsBySecretResponse {
+    pub cfrags: Vec<CFragEntry>,
+}
+
+/// A single cFrag entry returned from AO contract
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CFragEntry {
+    pub cfrag_data: Binary,
+    pub holder_id: String,
+}
+
+// =====================================================================
+// AO Message Tags
+// =====================================================================
+
+/// Tags for AO messages (metadata)
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AOMessageTags {
+    /// Application name (always "cwao" for CosmWasm AO)
+    pub app_name: String,
+    /// Action being performed
+    pub action: String,
+    /// Whether this is a read-only operation
+    pub read_only: String,
+    /// JSON-encoded input payload
+    pub input: String,
+    /// Target process ID
+    pub process_id: String,
+    /// Actor (sender) address
+    pub actor: String,
+    /// Timestamp
+    pub ts: String,
+}
+
+impl AOMessageTags {
+    /// Create tags for an execute (state-changing) message
+    pub fn new_execute(action: &str, input: &str, process_id: &str, actor: &str, ts: &str) -> Self {
+        Self {
+            app_name: "cwao".to_string(),
+            action: action.to_string(),
+            read_only: "False".to_string(),
+            input: input.to_string(),
+            process_id: process_id.to_string(),
+            actor: actor.to_string(),
+            ts: ts.to_string(),
+        }
+    }
+
+    /// Create tags for a query (read-only) message
+    pub fn new_query(action: &str, input: &str, process_id: &str, actor: &str, ts: &str) -> Self {
+        Self {
+            app_name: "cwao".to_string(),
+            action: action.to_string(),
+            read_only: "True".to_string(),
+            input: input.to_string(),
+            process_id: process_id.to_string(),
+            actor: actor.to_string(),
+            ts: ts.to_string(),
+        }
+    }
+
+    /// Check if this is a read-only operation
+    pub fn is_read_only(&self) -> bool {
+        self.read_only == "True"
+    }
+}
+
+// =====================================================================
+// Message Validation
+// =====================================================================
+
+/// Trait for validating AO messages
+pub trait ValidateMessage {
+    /// Validate the message contents
+    fn validate(&self) -> Result<(), String>;
+}
+
+impl ValidateMessage for ExecuteMsg {
+    fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::DelegateKFrag { kfrag_id, kfrag } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_binary_data(kfrag, "kfrag")?;
+                Ok(())
+            }
+            Self::DelegateCapsule {
+                kfrag_id,
+                capsule_id,
+                capsule,
+            } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_capsule_id(capsule_id)?;
+                validate_binary_data(capsule, "capsule")?;
+                Ok(())
+            }
+            Self::SubmitKFrag { kfrag_id, kfrag } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_binary_data(kfrag, "kfrag")?;
+                Ok(())
+            }
+            Self::SubmitCapsule {
+                kfrag_id,
+                capsule_id,
+                capsule,
+            } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_capsule_id(capsule_id)?;
+                validate_binary_data(capsule, "capsule")?;
+                Ok(())
+            }
+            Self::Reencrypt {
+                kfrag_id,
+                capsule_id,
+            } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_capsule_id(capsule_id)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ValidateMessage for QueryMsg {
+    fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::GetCFrag {
+                kfrag_id,
+                capsule_id,
+            } => {
+                validate_kfrag_id(kfrag_id)?;
+                validate_capsule_id(capsule_id)?;
+                Ok(())
+            }
+            Self::ListCapsulesByKFrag {
+                kfrag_id,
+                start_after,
+                limit,
+            } => {
+                validate_kfrag_id(kfrag_id)?;
+                if let Some(start_after) = start_after {
+                    validate_capsule_id(start_after)?;
+                }
+                if let Some(limit) = limit {
+                    if *limit == 0 || *limit > 100 {
+                        return Err("limit must be between 1 and 100".to_string());
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+// =====================================================================
+// Validation helpers
+// =====================================================================
+
+/// Maximum length for IDs (kfrag_id, capsule_id, etc.)
+pub const MAX_ID_LENGTH: usize = 128;
+
+/// Maximum size for binary data (128KB)
+pub const MAX_BINARY_SIZE: usize = 128 * 1024;
+
+/// Validate a KFrag ID
+#[allow(dead_code)]
+pub fn validate_kfrag_id(id: &str) -> Result<(), String> {
+    validate_id(id, "kfrag_id")
+}
+
+/// Validate a Capsule ID
+#[allow(dead_code)]
+pub fn validate_capsule_id(id: &str) -> Result<(), String> {
+    validate_id(id, "capsule_id")
+}
+
+/// Validate a process ID
+#[allow(dead_code)]
+pub fn validate_process_id(id: &str) -> Result<(), String> {
+    validate_id(id, "process_id")
+}
+
+/// Generic ID validation
+fn validate_id(id: &str, field_name: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err(format!("{field_name} cannot be empty"));
+    }
+    if id.len() > MAX_ID_LENGTH {
+        return Err(format!(
+            "{field_name} must be <= {MAX_ID_LENGTH} characters"
+        ));
+    }
+
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(format!(
+            "{field_name} must contain only ASCII alphanumeric, underscore, or hyphen"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate binary data
+pub fn validate_binary_data(binary: &Binary, field_name: &str) -> Result<(), String> {
+    if binary.is_empty() {
+        return Err(format!("{field_name} cannot be empty"));
+    }
+
+    if binary.len() > MAX_BINARY_SIZE {
+        let max_kb = MAX_BINARY_SIZE / 1024;
+        return Err(format!("{field_name} exceeds maximum size of {max_kb}KB"));
+    }
+
+    Ok(())
+}

--- a/client/src/adapter/external/ao_cwao/mod.rs
+++ b/client/src/adapter/external/ao_cwao/mod.rs
@@ -1,0 +1,32 @@
+//! AO Network client module
+//!
+//! Provides production implementation of AOClient trait
+//! for AO Network communication.
+//!
+//! ## Module Structure
+//!
+//! - `client` - AOClient trait definition
+//! - `config` - AO Network connection configuration
+//! - `message` - Message types for AO communication
+//! - `data_item` - ANS-104 DataItem builder and signer (production feature)
+//! - `production_client` - Production AOClient implementation (production feature)
+
+mod client;
+mod config;
+#[cfg(feature = "production-ao")]
+mod data_item;
+mod message;
+#[cfg(feature = "production-ao")]
+mod production_client;
+
+pub use client::AOClient;
+pub use config::AOConfig;
+#[cfg(feature = "production-ao")]
+pub use data_item::{ArweaveJWK, DataItemBuilder, DataItemSigner};
+pub use message::{
+    AOAttribute, AOEvent, AOMessageTags, AOResponse, Binary, BlobMeta, CFragEntry, CapsuleInfo,
+    CapsuleStatus, ExecuteMsg, GetCFragResponse, GetCFragsBySecretResponse,
+    ListCapsulesByKFragResponse, QueryMsg, ValidateMessage, MAX_BINARY_SIZE, MAX_ID_LENGTH,
+};
+#[cfg(feature = "production-ao")]
+pub use production_client::ProductionAOClient;

--- a/client/src/adapter/external/ao_cwao/production_client.rs
+++ b/client/src/adapter/external/ao_cwao/production_client.rs
@@ -1,10 +1,4 @@
-//! ProductionAOClient for HyperBEAM AO Network.
-//!
-//! Port of `ao_cwao/production_client.rs`.
-//! HTTP MU/CU communication is unchanged; message types are updated
-//! to `AOExecuteMsg` / `AOQueryMsg` / `AONativeResponse`.
-
-#![allow(clippy::large_futures)]
+#![allow(clippy::disallowed_names, clippy::large_futures)]
 
 use async_trait::async_trait;
 use reqwest::Client;
@@ -12,7 +6,7 @@ use reqwest::Client;
 use super::client::AOClient;
 use super::config::AOConfig;
 use super::data_item::{ArweaveJWK, DataItemBuilder, DataItemSigner};
-use super::message::{AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary};
+use super::message::{AOResponse, Binary, ExecuteMsg, QueryMsg};
 use crate::adapter::errors::AOCommunicationError;
 
 pub struct ProductionAOClient {
@@ -24,18 +18,26 @@ pub struct ProductionAOClient {
 impl ProductionAOClient {
     pub fn new(config: AOConfig, jwk: &ArweaveJWK) -> Result<Self, AOCommunicationError> {
         let signer = DataItemSigner::new(jwk)?;
+
         let http_client = Client::builder()
             .timeout(std::time::Duration::from_millis(config.timeout_ms()))
             .build()
             .map_err(|e| AOCommunicationError::ConnectionError {
                 details: format!("Failed to create HTTP client: {e}"),
             })?;
-        Ok(Self { config, http_client, signer })
+
+        Ok(Self {
+            config,
+            http_client,
+            signer,
+        })
     }
 
     async fn post_to_mu(&self, item_bytes: &[u8]) -> Result<String, AOCommunicationError> {
-        let response = self.http_client
-            .post(self.config.mu_url())
+        let url = self.config.mu_url();
+        let response = self
+            .http_client
+            .post(url)
             .header("Content-Type", "application/octet-stream")
             .body(item_bytes.to_vec())
             .send()
@@ -44,19 +46,24 @@ impl ProductionAOClient {
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body_text = response.text().await.unwrap_or_default();
             return Err(AOCommunicationError::ExecutionError {
                 process_id: String::new(),
-                details: format!("MU returned {status}: {body}"),
+                details: format!("MU returned status {status}: {body_text}"),
             });
         }
-        let body: serde_json::Value = response.json().await
-            .map_err(|e| AOCommunicationError::DeserializationError {
-                details: format!("MU response parse: {e}"),
-            })?;
-        body["id"].as_str().map(str::to_string).ok_or_else(|| {
+
+        let body: serde_json::Value =
+            response
+                .json()
+                .await
+                .map_err(|e| AOCommunicationError::DeserializationError {
+                    details: format!("Failed to parse MU response: {e}"),
+                })?;
+
+        body["id"].as_str().map(|s| s.to_string()).ok_or_else(|| {
             AOCommunicationError::DeserializationError {
-                details: "MU response missing 'id'".to_string(),
+                details: "MU response missing 'id' field".to_string(),
             }
         })
     }
@@ -68,9 +75,16 @@ impl ProductionAOClient {
     ) -> Result<serde_json::Value, AOCommunicationError> {
         let url = format!(
             "{}/result/{}?process-id={}&no-busy",
-            self.config.cu_url(), message_id, process_id
+            self.config.cu_url(),
+            message_id,
+            process_id
         );
-        let response = self.http_client.get(&url).send().await
+
+        let response = self
+            .http_client
+            .get(&url)
+            .send()
+            .await
             .map_err(|e| Self::map_reqwest_error(&e, "CU result", self.config.timeout_ms()))?;
 
         let status = response.status();
@@ -82,12 +96,16 @@ impl ProductionAOClient {
         if !status.is_success() {
             return Err(AOCommunicationError::ExecutionError {
                 process_id: process_id.to_string(),
-                details: format!("CU returned {status}"),
+                details: format!("CU returned status {status}"),
             });
         }
-        response.json().await.map_err(|e| AOCommunicationError::DeserializationError {
-            details: format!("CU result parse: {e}"),
-        })
+
+        response
+            .json()
+            .await
+            .map_err(|e| AOCommunicationError::DeserializationError {
+                details: format!("Failed to parse CU result: {e}"),
+            })
     }
 
     async fn post_cu_dry_run(
@@ -96,7 +114,13 @@ impl ProductionAOClient {
         body: serde_json::Value,
     ) -> Result<serde_json::Value, AOCommunicationError> {
         let url = format!("{}/dry-run?process-id={}", self.config.cu_url(), process_id);
-        let response = self.http_client.post(&url).json(&body).send().await
+
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
             .map_err(|e| Self::map_reqwest_error(&e, "CU dry-run", self.config.timeout_ms()))?;
 
         let status = response.status();
@@ -108,22 +132,23 @@ impl ProductionAOClient {
         if !status.is_success() {
             return Err(AOCommunicationError::ExecutionError {
                 process_id: process_id.to_string(),
-                details: format!("CU dry-run returned {status}"),
+                details: format!("CU dry-run returned status {status}"),
             });
         }
-        response.json().await.map_err(|e| AOCommunicationError::DeserializationError {
-            details: format!("CU dry-run parse: {e}"),
-        })
+
+        response
+            .json()
+            .await
+            .map_err(|e| AOCommunicationError::DeserializationError {
+                details: format!("Failed to parse CU dry-run response: {e}"),
+            })
     }
 
-    /// Parse AO-native response from CU result.
-    /// The new contract returns `{ "ok": bool, "data": {...}, "error": "..." }`.
     fn parse_cu_result(
         process_id: &str,
         json: &serde_json::Value,
         message_id: Option<String>,
-    ) -> Result<AONativeResponse, AOCommunicationError> {
-        // First check for AO-level error (process not found, etc.)
+    ) -> Result<AOResponse, AOCommunicationError> {
         if let Some(error) = json.get("Error") {
             if !error.is_null() {
                 return Err(AOCommunicationError::ExecutionError {
@@ -133,35 +158,46 @@ impl ProductionAOClient {
             }
         }
 
-        // Try to extract Output.data as AO-native JSON response
         let output = json.get("Output");
-        if let Some(obj) = output {
-            // AO Output.data contains our JSON response string
-            if let Some(data_str) = obj.get("data").and_then(|d| d.as_str()) {
-                // Try to parse as AONativeResponse
-                if let Ok(mut native_resp) = serde_json::from_str::<AONativeResponse>(data_str) {
-                    native_resp.message_id = message_id;
-                    return Ok(native_resp);
-                }
-                // Fallback: treat as raw data
-                return Ok(AONativeResponse {
-                    ok: true,
-                    data: Some(serde_json::Value::String(data_str.to_string())),
-                    error: None,
-                    message_id,
-                });
+        let data = if let Some(obj) = output {
+            if let Some(data_str) = obj
+                .get("data")
+                .and_then(|d| d.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                use base64::{
+                    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+                    Engine,
+                };
+                Some(
+                    match STANDARD
+                        .decode(data_str)
+                        .or_else(|_| URL_SAFE_NO_PAD.decode(data_str))
+                    {
+                        Ok(decoded) => Binary::from(decoded),
+                        Err(_) => Binary::from(data_str.as_bytes().to_vec()),
+                    },
+                )
+            } else if obj.is_object() || obj.is_array() {
+                let serialized = serde_json::to_vec(obj).map_err(|e| {
+                    AOCommunicationError::DeserializationError {
+                        details: format!("Failed to serialize Output: {e}"),
+                    }
+                })?;
+                Some(Binary::from(serialized))
+            } else {
+                None
             }
-            if obj.is_object() || obj.is_array() {
-                return Ok(AONativeResponse {
-                    ok: true,
-                    data: Some(obj.clone()),
-                    error: None,
-                    message_id,
-                });
-            }
-        }
+        } else {
+            None
+        };
 
-        Ok(AONativeResponse { ok: true, data: None, error: None, message_id })
+        Ok(AOResponse {
+            success: true,
+            data,
+            events: Vec::new(),
+            message_id,
+        })
     }
 
     fn parse_cu_dryrun_data(
@@ -177,21 +213,28 @@ impl ProductionAOClient {
             }
         }
 
-        if let Some(obj) = json.get("Output") {
+        let output = json.get("Output");
+
+        if let Some(obj) = output {
+            // Standard AO CU: Output.data is a base64-encoded string
             if let Some(data_str) = obj.get("data").and_then(|d| d.as_str()) {
-                // Try base64 decode, fallback to raw bytes
-                use base64::{engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD}, Engine};
-                return match STANDARD.decode(data_str)
+                use base64::{
+                    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+                    Engine,
+                };
+                return match STANDARD
+                    .decode(data_str)
                     .or_else(|_| URL_SAFE_NO_PAD.decode(data_str))
                 {
                     Ok(decoded) => Ok(Binary::from(decoded)),
                     Err(_) => Ok(Binary::from(data_str.as_bytes().to_vec())),
                 };
             }
+            // CWAO CU: Output is a direct JSON object/array without data field
             if obj.is_object() || obj.is_array() {
                 let serialized = serde_json::to_vec(obj).map_err(|e| {
                     AOCommunicationError::DeserializationError {
-                        details: format!("Output serialize: {e}"),
+                        details: format!("Failed to serialize Output: {e}"),
                     }
                 })?;
                 return Ok(Binary::from(serialized));
@@ -201,15 +244,24 @@ impl ProductionAOClient {
         Ok(Binary::from(Vec::new()))
     }
 
-    fn map_reqwest_error(err: &reqwest::Error, operation: &str, timeout_ms: u64) -> AOCommunicationError {
+    fn map_reqwest_error(
+        err: &reqwest::Error,
+        operation: &str,
+        timeout_ms: u64,
+    ) -> AOCommunicationError {
         if err.is_timeout() {
-            AOCommunicationError::Timeout { operation: operation.to_string(), timeout_ms }
+            AOCommunicationError::Timeout {
+                operation: operation.to_string(),
+                timeout_ms,
+            }
         } else if err.is_connect() {
-            AOCommunicationError::ConnectionError { details: format!("{operation} connect: {err}") }
+            AOCommunicationError::ConnectionError {
+                details: format!("{operation} connection failed: {err}"),
+            }
         } else {
             AOCommunicationError::ExecutionError {
                 process_id: String::new(),
-                details: format!("{operation}: {err}"),
+                details: format!("{operation} failed: {err}"),
             }
         }
     }
@@ -220,8 +272,8 @@ impl AOClient for ProductionAOClient {
     async fn execute(
         &self,
         process_id: &str,
-        msg: AOExecuteMsg,
-    ) -> Result<AONativeResponse, AOCommunicationError> {
+        msg: ExecuteMsg,
+    ) -> Result<AOResponse, AOCommunicationError> {
         let item = DataItemBuilder::build_execute(process_id, &msg)?;
         let signed_bytes = self.signer.sign(&item)?;
         let message_id = self.post_to_mu(&signed_bytes).await?;
@@ -229,11 +281,7 @@ impl AOClient for ProductionAOClient {
         Self::parse_cu_result(process_id, &result_json, Some(message_id))
     }
 
-    async fn query(
-        &self,
-        process_id: &str,
-        msg: AOQueryMsg,
-    ) -> Result<Binary, AOCommunicationError> {
+    async fn query(&self, process_id: &str, msg: QueryMsg) -> Result<Binary, AOCommunicationError> {
         let body = DataItemBuilder::build_query_body(process_id, &msg)?;
         let result_json = self.post_cu_dry_run(process_id, body).await?;
         Self::parse_cu_dryrun_data(process_id, &result_json)
@@ -242,8 +290,8 @@ impl AOClient for ProductionAOClient {
     async fn dry_run(
         &self,
         process_id: &str,
-        msg: AOExecuteMsg,
-    ) -> Result<AONativeResponse, AOCommunicationError> {
+        msg: ExecuteMsg,
+    ) -> Result<AOResponse, AOCommunicationError> {
         let body = DataItemBuilder::build_dry_run_body(process_id, &msg)?;
         let result_json = self.post_cu_dry_run(process_id, body).await?;
         Self::parse_cu_result(process_id, &result_json, None)

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -231,7 +231,21 @@ impl AOClient for MockAOClient {
                 let capsule_id = data_str(d, "capsule_id")?;
                 let capsule = data_bytes(d, "capsule")?;
                 let holder_process_id = data_str(d, "holder_process_id")?;
-                // Route capsule to holder_process_id (mirrors contract OutgoingMessage)
+                // Mirror contract: verify holder was registered via DelegateKFrag
+                {
+                    let holders = self.kfrag_holders.read().unwrap();
+                    let registered = holders
+                        .get(process_id)
+                        .and_then(|m| m.get(kfrag_id));
+                    if registered.is_none() {
+                        return Err(AOCommunicationError::ExecutionError {
+                            process_id: process_id.to_string(),
+                            details: format!(
+                                "No holder registered for kfrag_id: {kfrag_id}"
+                            ),
+                        });
+                    }
+                }
                 self.store_capsule(holder_process_id, kfrag_id, capsule_id, capsule);
                 Ok(AONativeResponse::success(
                     serde_json::json!({ "capsule_id": capsule_id, "delegated": true }),

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -32,10 +32,14 @@ pub struct MockConfig {
 type CapsuleStorage = HashMap<String, HashMap<String, (String, Vec<u8>)>>;
 
 /// Mock AO Client for testing and development.
+/// Type alias: process_id -> (kfrag_id -> holder_process_id)
+type KFragHolderMap = HashMap<String, HashMap<String, String>>;
+
 pub struct MockAOClient {
     kfrag_storage: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
     cfrag_storage: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
     capsule_storage: RwLock<CapsuleStorage>,
+    kfrag_holders: RwLock<KFragHolderMap>,
     #[allow(dead_code)]
     config: MockConfig,
     error_injection: RwLock<Option<AOCommunicationError>>,
@@ -49,6 +53,7 @@ impl MockAOClient {
             kfrag_storage: RwLock::new(HashMap::new()),
             cfrag_storage: RwLock::new(HashMap::new()),
             capsule_storage: RwLock::new(HashMap::new()),
+            kfrag_holders: RwLock::new(HashMap::new()),
             config: MockConfig::default(),
             error_injection: RwLock::new(None),
             ok_false_injection: RwLock::new(None),
@@ -59,6 +64,7 @@ impl MockAOClient {
             kfrag_storage: RwLock::new(HashMap::new()),
             cfrag_storage: RwLock::new(HashMap::new()),
             capsule_storage: RwLock::new(HashMap::new()),
+            kfrag_holders: RwLock::new(HashMap::new()),
             config,
             error_injection: RwLock::new(None),
             ok_false_injection: RwLock::new(None),
@@ -78,20 +84,31 @@ impl MockAOClient {
 
     pub fn get_stored_kfrags(&self, process_id: &str) -> Vec<(String, Vec<u8>)> {
         let s = self.kfrag_storage.read().unwrap();
-        s.get(process_id).map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()).unwrap_or_default()
+        s.get(process_id)
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
     }
     pub fn get_stored_cfrags(&self, process_id: &str) -> Vec<(String, Vec<u8>)> {
         let s = self.cfrag_storage.read().unwrap();
-        s.get(process_id).map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()).unwrap_or_default()
+        s.get(process_id)
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
     }
     pub fn get_stored_capsules(&self, process_id: &str) -> Vec<(String, String, Vec<u8>)> {
         let s = self.capsule_storage.read().unwrap();
-        s.get(process_id).map(|m| m.iter().map(|(cid, (kid, d))| (cid.clone(), kid.clone(), d.clone())).collect()).unwrap_or_default()
+        s.get(process_id)
+            .map(|m| {
+                m.iter()
+                    .map(|(cid, (kid, d))| (cid.clone(), kid.clone(), d.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
     pub fn clear(&self) {
         self.kfrag_storage.write().unwrap().clear();
         self.cfrag_storage.write().unwrap().clear();
         self.capsule_storage.write().unwrap().clear();
+        self.kfrag_holders.write().unwrap().clear();
     }
 
     fn check_error_injection(&self) -> Option<AOCommunicationError> {
@@ -101,14 +118,29 @@ impl MockAOClient {
         self.ok_false_injection.write().unwrap().take()
     }
     fn store_kfrag(&self, process_id: &str, kfrag_id: &str, data: Vec<u8>) {
-        self.kfrag_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(kfrag_id.to_string(), data);
+        self.kfrag_storage
+            .write()
+            .unwrap()
+            .entry(process_id.to_string())
+            .or_default()
+            .insert(kfrag_id.to_string(), data);
     }
     fn store_capsule(&self, process_id: &str, kfrag_id: &str, capsule_id: &str, data: Vec<u8>) {
-        self.capsule_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(capsule_id.to_string(), (kfrag_id.to_string(), data));
+        self.capsule_storage
+            .write()
+            .unwrap()
+            .entry(process_id.to_string())
+            .or_default()
+            .insert(capsule_id.to_string(), (kfrag_id.to_string(), data));
     }
     fn store_cfrag(&self, process_id: &str, kfrag_id: &str, capsule_id: &str, data: Vec<u8>) {
         let key = format!("{kfrag_id}:{capsule_id}");
-        self.cfrag_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(key, data);
+        self.cfrag_storage
+            .write()
+            .unwrap()
+            .entry(process_id.to_string())
+            .or_default()
+            .insert(key, data);
     }
     fn get_cfrag(&self, process_id: &str, kfrag_id: &str, capsule_id: &str) -> Option<Vec<u8>> {
         let key = format!("{kfrag_id}:{capsule_id}");
@@ -118,31 +150,36 @@ impl MockAOClient {
 }
 
 impl Default for MockAOClient {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Extract a string field from `msg.data` JSON.
 fn data_str<'a>(data: &'a serde_json::Value, field: &str) -> Result<&'a str, AOCommunicationError> {
-    data.get(field).and_then(|v| v.as_str()).ok_or_else(|| {
-        AOCommunicationError::ValidationError { details: format!("missing field: {field}") }
-    })
+    data.get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AOCommunicationError::ValidationError {
+            details: format!("missing field: {field}"),
+        })
 }
 /// Extract bytes from `msg.data[field]` (JSON array of u8 values, 0..=255).
 /// Returns an error if the field is missing, not an array, or contains out-of-range values.
 fn data_bytes(data: &serde_json::Value, field: &str) -> Result<Vec<u8>, AOCommunicationError> {
-    let arr = data
-        .get(field)
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| AOCommunicationError::ValidationError {
+    let arr = data.get(field).and_then(|v| v.as_array()).ok_or_else(|| {
+        AOCommunicationError::ValidationError {
             details: format!("missing or non-array field: {field}"),
-        })?;
+        }
+    })?;
 
     arr.iter()
         .enumerate()
         .map(|(i, v)| {
-            let n = v.as_u64().ok_or_else(|| AOCommunicationError::ValidationError {
-                details: format!("field {field}[{i}] is not a number"),
-            })?;
+            let n = v
+                .as_u64()
+                .ok_or_else(|| AOCommunicationError::ValidationError {
+                    details: format!("field {field}[{i}] is not a number"),
+                })?;
             if n > 255 {
                 return Err(AOCommunicationError::ValidationError {
                     details: format!("field {field}[{i}] = {n} is out of u8 range (0..=255)"),
@@ -160,12 +197,16 @@ impl AOClient for MockAOClient {
         process_id: &str,
         msg: AOExecuteMsg,
     ) -> Result<AONativeResponse, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() { return Err(err); }
+        if let Some(err) = self.check_error_injection() {
+            return Err(err);
+        }
         if let Some(reason) = self.check_ok_false_injection() {
             return Ok(AONativeResponse::error_response(reason));
         }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
+            return Err(AOCommunicationError::ValidationError {
+                details: "empty process ID".into(),
+            });
         }
 
         let d = msg.data();
@@ -173,21 +214,36 @@ impl AOClient for MockAOClient {
             "DelegateKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let kfrag = data_bytes(d, "kfrag")?;
+                let holder_process_id = data_str(d, "holder_process_id")?;
                 self.store_kfrag(process_id, kfrag_id, kfrag);
-                Ok(AONativeResponse::success(serde_json::json!({ "kfrag_id": kfrag_id, "delegated": true })))
+                self.kfrag_holders
+                    .write()
+                    .unwrap()
+                    .entry(process_id.to_string())
+                    .or_default()
+                    .insert(kfrag_id.to_string(), holder_process_id.to_string());
+                Ok(AONativeResponse::success(
+                    serde_json::json!({ "kfrag_id": kfrag_id, "delegated": true }),
+                ))
             }
             "DelegateCapsule" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
                 let capsule = data_bytes(d, "capsule")?;
-                self.store_capsule(process_id, kfrag_id, capsule_id, capsule);
-                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "delegated": true })))
+                let holder_process_id = data_str(d, "holder_process_id")?;
+                // Route capsule to holder_process_id (mirrors contract OutgoingMessage)
+                self.store_capsule(holder_process_id, kfrag_id, capsule_id, capsule);
+                Ok(AONativeResponse::success(
+                    serde_json::json!({ "capsule_id": capsule_id, "delegated": true }),
+                ))
             }
             "SubmitKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let kfrag = data_bytes(d, "kfrag")?;
                 self.store_kfrag(process_id, kfrag_id, kfrag);
-                Ok(AONativeResponse::success(serde_json::json!({ "kfrag_id": kfrag_id, "stored": true })))
+                Ok(AONativeResponse::success(
+                    serde_json::json!({ "kfrag_id": kfrag_id, "stored": true }),
+                ))
             }
             "SubmitCapsule" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
@@ -197,14 +253,18 @@ impl AOClient for MockAOClient {
                 let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
                 self.store_capsule(process_id, kfrag_id, capsule_id, capsule);
                 self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
-                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true })))
+                Ok(AONativeResponse::success(
+                    serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
+                ))
             }
             "Reencrypt" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
                 let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
                 self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
-                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true })))
+                Ok(AONativeResponse::success(
+                    serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
+                ))
             }
             other => Err(AOCommunicationError::ExecutionError {
                 process_id: process_id.to_string(),
@@ -218,9 +278,13 @@ impl AOClient for MockAOClient {
         process_id: &str,
         msg: AOQueryMsg,
     ) -> Result<Binary, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() { return Err(err); }
+        if let Some(err) = self.check_error_injection() {
+            return Err(err);
+        }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
+            return Err(AOCommunicationError::ValidationError {
+                details: "empty process ID".into(),
+            });
         }
 
         let d = msg.data();
@@ -228,19 +292,22 @@ impl AOClient for MockAOClient {
             "GetCFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
-                let cfrag_data = self.get_cfrag(process_id, kfrag_id, capsule_id).ok_or_else(|| {
-                    AOCommunicationError::ExecutionError {
+                let cfrag_data = self
+                    .get_cfrag(process_id, kfrag_id, capsule_id)
+                    .ok_or_else(|| AOCommunicationError::ExecutionError {
                         process_id: process_id.to_string(),
                         details: "CFrag not ready".to_string(),
-                    }
-                })?;
+                    })?;
                 let response = GetCFragResponse {
                     kfrag_id: kfrag_id.to_string(),
                     capsule_id: capsule_id.to_string(),
                     cfrag: cfrag_data,
                 };
-                let json = serde_json::to_vec(&response)
-                    .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+                let json = serde_json::to_vec(&response).map_err(|e| {
+                    AOCommunicationError::SerializationError {
+                        details: e.to_string(),
+                    }
+                })?;
                 Ok(Binary::from(json))
             }
             "ListCapsules" => {
@@ -250,11 +317,14 @@ impl AOClient for MockAOClient {
                 let limit = d.get("limit").and_then(|v| v.as_u64()).unwrap_or(100) as usize;
 
                 let s = self.capsule_storage.read().unwrap();
-                let mut capsule_ids: Vec<String> = s.get(process_id)
-                    .map(|m| m.iter()
-                        .filter(|(_, (kid, _))| kid.as_str() == kfrag_id)
-                        .map(|(cid, _)| cid.clone())
-                        .collect())
+                let mut capsule_ids: Vec<String> = s
+                    .get(process_id)
+                    .map(|m| {
+                        m.iter()
+                            .filter(|(_, (kid, _))| kid.as_str() == kfrag_id)
+                            .map(|(cid, _)| cid.clone())
+                            .collect()
+                    })
                     .unwrap_or_default();
 
                 // Deterministic order + pagination (matches production contract behaviour)
@@ -272,7 +342,9 @@ impl AOClient for MockAOClient {
                     "capsule_ids": capsule_ids,
                     "next_start_after": next_start_after,
                 }))
-                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+                .map_err(|e| AOCommunicationError::SerializationError {
+                    details: e.to_string(),
+                })?;
                 Ok(Binary::from(json))
             }
             other => Err(AOCommunicationError::ExecutionError {
@@ -287,11 +359,17 @@ impl AOClient for MockAOClient {
         process_id: &str,
         msg: AOExecuteMsg,
     ) -> Result<AONativeResponse, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() { return Err(err); }
+        if let Some(err) = self.check_error_injection() {
+            return Err(err);
+        }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
+            return Err(AOCommunicationError::ValidationError {
+                details: "empty process ID".into(),
+            });
         }
         // Dry-run: simulate without side-effects
-        Ok(AONativeResponse::success(serde_json::json!({ "dry_run": true, "action": msg.action() })))
+        Ok(AONativeResponse::success(
+            serde_json::json!({ "dry_run": true, "action": msg.action() }),
+        ))
     }
 }

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements `AOClient` from `ao/` using `AOExecuteMsg`/`AOQueryMsg`/`AONativeResponse`.
 //! All business logic dispatches on `msg.action()` string instead of enum variants.
+//! Uses real Umbral proxy re-encryption for DelegateCapsule/SubmitCapsule/Reencrypt.
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::disallowed_names)]
@@ -12,11 +13,33 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use async_trait::async_trait;
+use serde::Deserialize;
+use umbral_pre::{DefaultDeserialize, DefaultSerialize};
 
 use crate::adapter::errors::AOCommunicationError;
 use crate::adapter::external::ao::{
     AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
 };
+
+// ─── Local structs mirroring contract's StoredKeyFrag / VerificationData ──────
+// Duplicated here to avoid layering dependency on ao/contracts.
+
+#[derive(Deserialize)]
+struct MockStoredKeyFrag {
+    #[allow(dead_code)]
+    id: String,
+    key_data: Vec<u8>,
+    verification_data: Vec<u8>,
+    #[allow(dead_code)]
+    precursor: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+struct MockVerificationData {
+    verifying_pk: Vec<u8>,
+    delegating_pk: Vec<u8>,
+    receiving_pk: Vec<u8>,
+}
 
 /// Configuration for MockAOClient behavior
 #[derive(Debug, Clone, Default)]
@@ -155,6 +178,102 @@ impl Default for MockAOClient {
     }
 }
 
+/// Real Umbral proxy re-encryption (ported from ao/contracts/src/handlers.rs:402-464).
+/// Takes bincode-serialized StoredKeyFragPayload and raw Capsule bytes.
+/// Returns raw CapsuleFrag bytes (suitable for `CapsuleFrag::from_bytes`).
+fn perform_reencryption(
+    kfrag_bytes: &[u8],
+    capsule_bytes: &[u8],
+) -> Result<Vec<u8>, AOCommunicationError> {
+    if kfrag_bytes.is_empty() {
+        return Err(AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Empty kFrag payload".to_string(),
+        });
+    }
+    if capsule_bytes.is_empty() {
+        return Err(AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Empty capsule payload".to_string(),
+        });
+    }
+
+    let stored_kfrag: MockStoredKeyFrag =
+        bincode::deserialize(kfrag_bytes).map_err(|e| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: format!("KFrag deserialize failed: {e}"),
+        })?;
+
+    if stored_kfrag.key_data.is_empty() {
+        return Err(AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Invalid kFrag data".to_string(),
+        });
+    }
+    if stored_kfrag.verification_data.is_empty() {
+        return Err(AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Missing verification data".to_string(),
+        });
+    }
+
+    let verification: MockVerificationData = bincode::deserialize(&stored_kfrag.verification_data)
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Invalid verification payload".to_string(),
+        })?;
+
+    let verifying_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.verifying_pk)
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Invalid verifying key".to_string(),
+        })?;
+
+    let delegating_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.delegating_pk)
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Invalid delegating key".to_string(),
+        })?;
+
+    let receiving_pk: umbral_pre::PublicKey = bincode::deserialize(&verification.receiving_pk)
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Invalid receiving key".to_string(),
+        })?;
+
+    let key_frag = umbral_pre::KeyFrag::from_bytes(&stored_kfrag.key_data).map_err(|_| {
+        AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Failed to deserialize kFrag".to_string(),
+        }
+    })?;
+
+    let verified_kfrag = key_frag
+        .verify(&verifying_pk, Some(&delegating_pk), Some(&receiving_pk))
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "kFrag verification failed".to_string(),
+        })?;
+
+    // Client serializes capsules with bincode (see crypto.rs:create_pre_capsule)
+    let capsule: umbral_pre::Capsule =
+        bincode::deserialize(capsule_bytes).map_err(|e| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: format!("Capsule deserialize failed: {e:?}"),
+        })?;
+
+    let verified_cfrag = umbral_pre::reencrypt(&capsule, verified_kfrag);
+    let cfrag = verified_cfrag.unverify();
+    let cfrag_bytes = cfrag
+        .to_bytes()
+        .map_err(|_| AOCommunicationError::ExecutionError {
+            process_id: String::new(),
+            details: "Failed to serialize cFrag".to_string(),
+        })?;
+
+    Ok(cfrag_bytes.to_vec())
+}
+
 /// Extract a string field from `msg.data` JSON.
 fn data_str<'a>(data: &'a serde_json::Value, field: &str) -> Result<&'a str, AOCommunicationError> {
     data.get(field)
@@ -234,22 +353,37 @@ impl AOClient for MockAOClient {
                 // Mirror contract: verify holder was registered via DelegateKFrag
                 {
                     let holders = self.kfrag_holders.read().unwrap();
-                    let registered = holders
-                        .get(process_id)
-                        .and_then(|m| m.get(kfrag_id));
+                    let registered = holders.get(process_id).and_then(|m| m.get(kfrag_id));
                     if registered.is_none() {
                         return Err(AOCommunicationError::ExecutionError {
                             process_id: process_id.to_string(),
-                            details: format!(
-                                "No holder registered for kfrag_id: {kfrag_id}"
-                            ),
+                            details: format!("No holder registered for kfrag_id: {kfrag_id}"),
                         });
                     }
                 }
-                self.store_capsule(holder_process_id, kfrag_id, capsule_id, capsule);
-                Ok(AONativeResponse::success(
-                    serde_json::json!({ "capsule_id": capsule_id, "delegated": true }),
-                ))
+                self.store_capsule(holder_process_id, kfrag_id, capsule_id, capsule.clone());
+
+                // Perform real Umbral re-encryption (replacing dummy cFrag)
+                let kfrag_bytes = {
+                    let storage = self.kfrag_storage.read().unwrap();
+                    storage
+                        .get(process_id)
+                        .and_then(|m| m.get(kfrag_id))
+                        .cloned()
+                };
+                match kfrag_bytes {
+                    Some(kb) => {
+                        let cfrag = perform_reencryption(&kb, &capsule)?;
+                        self.store_cfrag(holder_process_id, kfrag_id, capsule_id, cfrag);
+                        Ok(AONativeResponse::success(
+                            serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
+                        ))
+                    }
+                    None => Err(AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: format!("KFrag not found for re-encryption: {kfrag_id}"),
+                    }),
+                }
             }
             "SubmitKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
@@ -263,22 +397,67 @@ impl AOClient for MockAOClient {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
                 let capsule = data_bytes(d, "capsule")?;
-                // Simulate re-encryption: store dummy cFrag
-                let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
-                self.store_capsule(process_id, kfrag_id, capsule_id, capsule);
-                self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
-                Ok(AONativeResponse::success(
-                    serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
-                ))
+                self.store_capsule(process_id, kfrag_id, capsule_id, capsule.clone());
+
+                // Perform real Umbral re-encryption (no dummy fallback)
+                let kfrag_bytes = {
+                    let storage = self.kfrag_storage.read().unwrap();
+                    storage
+                        .get(process_id)
+                        .and_then(|m| m.get(kfrag_id))
+                        .cloned()
+                };
+                match kfrag_bytes {
+                    Some(kb) => {
+                        let cfrag = perform_reencryption(&kb, &capsule)?;
+                        self.store_cfrag(process_id, kfrag_id, capsule_id, cfrag);
+                        Ok(AONativeResponse::success(
+                            serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
+                        ))
+                    }
+                    None => Err(AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: format!("KFrag not found for re-encryption: {kfrag_id}"),
+                    }),
+                }
             }
             "Reencrypt" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
-                let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
-                self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
-                Ok(AONativeResponse::success(
-                    serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
-                ))
+
+                // Look up kfrag and capsule, then perform real re-encryption
+                let kfrag_bytes = {
+                    let storage = self.kfrag_storage.read().unwrap();
+                    storage
+                        .get(process_id)
+                        .and_then(|m| m.get(kfrag_id))
+                        .cloned()
+                };
+                let capsule_bytes = {
+                    let storage = self.capsule_storage.read().unwrap();
+                    storage
+                        .get(process_id)
+                        .and_then(|m| m.get(capsule_id))
+                        .map(|(_, data)| data.clone())
+                };
+
+                match (kfrag_bytes, capsule_bytes) {
+                    (Some(kb), Some(cb)) => {
+                        let cfrag = perform_reencryption(&kb, &cb)?;
+                        self.store_cfrag(process_id, kfrag_id, capsule_id, cfrag);
+                        Ok(AONativeResponse::success(
+                            serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true }),
+                        ))
+                    }
+                    (None, _) => Err(AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: format!("KFrag not found: {kfrag_id}"),
+                    }),
+                    (_, None) => Err(AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: format!("Capsule not found: {capsule_id}"),
+                    }),
+                }
             }
             other => Err(AOCommunicationError::ExecutionError {
                 process_id: process_id.to_string(),

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -1,7 +1,7 @@
-//! Mock AO Network client implementation
+//! Mock AO Network client (updated for HyperBEAM-native message types)
 //!
-//! Provides MockAOClient for testing and development without
-//! actual AO Network connection.
+//! Implements `AOClient` from `ao/` using `AOExecuteMsg`/`AOQueryMsg`/`AONativeResponse`.
+//! All business logic dispatches on `msg.action` string instead of enum variants.
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::disallowed_names)]
@@ -15,43 +15,31 @@ use async_trait::async_trait;
 
 use crate::adapter::errors::AOCommunicationError;
 use crate::adapter::external::ao::{
-    AOClient, AOEvent, AOResponse, Binary, BlobMeta, CapsuleInfo, CapsuleStatus, ExecuteMsg,
-    GetCFragResponse, ListCapsulesByKFragResponse, QueryMsg, ValidateMessage,
+    AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
 };
 
 /// Configuration for MockAOClient behavior
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MockConfig {
-    /// Simulated network delay in milliseconds (not applied in current impl)
     pub delay_ms: Option<u64>,
-    /// Random failure rate (0.0 to 1.0) - not implemented in current version
     pub fail_rate: Option<f64>,
 }
 
-/// Type alias for capsule storage: process_id -> (capsule_id -> (kfrag_id, capsule_data))
+/// Type alias: process_id -> (capsule_id -> (kfrag_id, capsule_data))
 type CapsuleStorage = HashMap<String, HashMap<String, (String, Vec<u8>)>>;
 
-/// Mock AO Client for testing and development
-///
-/// Stores kFrags and cFrags in memory, allowing testing without
-/// actual AO Network connection.
+/// Mock AO Client for testing and development.
 pub struct MockAOClient {
-    /// Storage: process_id -> (kfrag_id -> kfrag_data)
     kfrag_storage: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
-    /// Storage: process_id -> (key -> cfrag_data) where key = "{kfrag_id}:{capsule_id}"
     cfrag_storage: RwLock<HashMap<String, HashMap<String, Vec<u8>>>>,
-    /// Capsule storage using type alias for readability
     capsule_storage: RwLock<CapsuleStorage>,
-    /// Configuration
     #[allow(dead_code)]
     config: MockConfig,
-    /// Error to inject on next operation
     error_injection: RwLock<Option<AOCommunicationError>>,
 }
 
 impl MockAOClient {
-    /// Create a new MockAOClient with default configuration
     pub fn new() -> Self {
         Self {
             kfrag_storage: RwLock::new(HashMap::new()),
@@ -61,8 +49,6 @@ impl MockAOClient {
             error_injection: RwLock::new(None),
         }
     }
-
-    /// Create a new MockAOClient with custom configuration
     pub fn with_config(config: MockConfig) -> Self {
         Self {
             kfrag_storage: RwLock::new(HashMap::new()),
@@ -73,161 +59,66 @@ impl MockAOClient {
         }
     }
 
-    /// Inject an error to be returned on the next operation
     pub fn inject_error(&self, error: AOCommunicationError) {
-        let mut injection = self.error_injection.write().unwrap();
-        *injection = Some(error);
+        *self.error_injection.write().unwrap() = Some(error);
     }
-
-    /// Clear any injected error
     pub fn clear_error(&self) {
-        let mut injection = self.error_injection.write().unwrap();
-        *injection = None;
+        *self.error_injection.write().unwrap() = None;
     }
 
-    /// Get all stored kFrags for a process
     pub fn get_stored_kfrags(&self, process_id: &str) -> Vec<(String, Vec<u8>)> {
-        let storage = self.kfrag_storage.read().unwrap();
-        storage
-            .get(process_id)
-            .map(|kfrags| {
-                kfrags
-                    .iter()
-                    .map(|(id, data)| (id.clone(), data.clone()))
-                    .collect()
-            })
-            .unwrap_or_default()
+        let s = self.kfrag_storage.read().unwrap();
+        s.get(process_id).map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()).unwrap_or_default()
     }
-
-    /// Get all stored cFrags for a process
     pub fn get_stored_cfrags(&self, process_id: &str) -> Vec<(String, Vec<u8>)> {
-        let storage = self.cfrag_storage.read().unwrap();
-        storage
-            .get(process_id)
-            .map(|cfrags| {
-                cfrags
-                    .iter()
-                    .map(|(id, data)| (id.clone(), data.clone()))
-                    .collect()
-            })
-            .unwrap_or_default()
+        let s = self.cfrag_storage.read().unwrap();
+        s.get(process_id).map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect()).unwrap_or_default()
     }
-
-    /// Get all stored capsules for a process
     pub fn get_stored_capsules(&self, process_id: &str) -> Vec<(String, String, Vec<u8>)> {
-        let storage = self.capsule_storage.read().unwrap();
-        storage
-            .get(process_id)
-            .map(|capsules| {
-                capsules
-                    .iter()
-                    .map(|(capsule_id, (kfrag_id, data))| {
-                        (capsule_id.clone(), kfrag_id.clone(), data.clone())
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
+        let s = self.capsule_storage.read().unwrap();
+        s.get(process_id).map(|m| m.iter().map(|(cid, (kid, d))| (cid.clone(), kid.clone(), d.clone())).collect()).unwrap_or_default()
     }
-
-    /// Clear all storage
     pub fn clear(&self) {
-        let mut kfrag_storage = self.kfrag_storage.write().unwrap();
-        let mut cfrag_storage = self.cfrag_storage.write().unwrap();
-        let mut capsule_storage = self.capsule_storage.write().unwrap();
-        kfrag_storage.clear();
-        cfrag_storage.clear();
-        capsule_storage.clear();
+        self.kfrag_storage.write().unwrap().clear();
+        self.cfrag_storage.write().unwrap().clear();
+        self.capsule_storage.write().unwrap().clear();
     }
 
-    /// Check if an error should be returned
     fn check_error_injection(&self) -> Option<AOCommunicationError> {
-        let mut injection = self.error_injection.write().unwrap();
-        injection.take()
+        self.error_injection.write().unwrap().take()
     }
-
-    /// Store a kFrag
-    fn store_kfrag(&self, process_id: &str, kfrag_id: &str, kfrag_data: Vec<u8>) {
-        let mut storage = self.kfrag_storage.write().unwrap();
-        storage
-            .entry(process_id.to_string())
-            .or_default()
-            .insert(kfrag_id.to_string(), kfrag_data);
+    fn store_kfrag(&self, process_id: &str, kfrag_id: &str, data: Vec<u8>) {
+        self.kfrag_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(kfrag_id.to_string(), data);
     }
-
-    /// Store a capsule
-    fn store_capsule(
-        &self,
-        process_id: &str,
-        kfrag_id: &str,
-        capsule_id: &str,
-        capsule_data: Vec<u8>,
-    ) {
-        let mut storage = self.capsule_storage.write().unwrap();
-        storage
-            .entry(process_id.to_string())
-            .or_default()
-            .insert(capsule_id.to_string(), (kfrag_id.to_string(), capsule_data));
+    fn store_capsule(&self, process_id: &str, kfrag_id: &str, capsule_id: &str, data: Vec<u8>) {
+        self.capsule_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(capsule_id.to_string(), (kfrag_id.to_string(), data));
     }
-
-    /// Store a cFrag (result of reencryption)
-    fn store_cfrag(&self, process_id: &str, kfrag_id: &str, capsule_id: &str, cfrag_data: Vec<u8>) {
+    fn store_cfrag(&self, process_id: &str, kfrag_id: &str, capsule_id: &str, data: Vec<u8>) {
         let key = format!("{kfrag_id}:{capsule_id}");
-        let mut storage = self.cfrag_storage.write().unwrap();
-        storage
-            .entry(process_id.to_string())
-            .or_default()
-            .insert(key, cfrag_data);
+        self.cfrag_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(key, data);
     }
-
-    /// Get a cFrag
     fn get_cfrag(&self, process_id: &str, kfrag_id: &str, capsule_id: &str) -> Option<Vec<u8>> {
         let key = format!("{kfrag_id}:{capsule_id}");
-        let storage = self.cfrag_storage.read().unwrap();
-        storage
-            .get(process_id)
-            .and_then(|cfrags| cfrags.get(&key).cloned())
-    }
-
-    /// List capsules by kFrag ID
-    fn list_capsules_by_kfrag(
-        &self,
-        process_id: &str,
-        kfrag_id: &str,
-        start_after: Option<&str>,
-        limit: Option<u32>,
-    ) -> Vec<(String, CapsuleStatus)> {
-        let storage = self.capsule_storage.read().unwrap();
-        let capsules = match storage.get(process_id) {
-            Some(c) => c,
-            None => return vec![],
-        };
-
-        let mut result: Vec<_> = capsules
-            .iter()
-            .filter(|(_, (kid, _))| kid == kfrag_id)
-            .map(|(capsule_id, _)| capsule_id.clone())
-            .collect();
-
-        result.sort();
-
-        if let Some(start) = start_after {
-            result.retain(|id| id.as_str() > start);
-        }
-
-        let limit = limit.unwrap_or(100) as usize;
-        result.truncate(limit);
-
-        result
-            .into_iter()
-            .map(|id| (id, CapsuleStatus::Pending))
-            .collect()
+        let s = self.cfrag_storage.read().unwrap();
+        s.get(process_id).and_then(|m| m.get(&key).cloned())
     }
 }
 
 impl Default for MockAOClient {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
+}
+
+/// Extract a string field from `msg.data` JSON.
+fn data_str<'a>(data: &'a serde_json::Value, field: &str) -> Result<&'a str, AOCommunicationError> {
+    data.get(field).and_then(|v| v.as_str()).ok_or_else(|| {
+        AOCommunicationError::ValidationError { details: format!("missing field: {field}") }
+    })
+}
+/// Extract bytes from `msg.data[field]` (JSON array of u8 values).
+fn data_bytes(data: &serde_json::Value, field: &str) -> Result<Vec<u8>, AOCommunicationError> {
+    data.get(field).and_then(|v| v.as_array()).map(|arr| {
+        arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()
+    }).ok_or_else(|| AOCommunicationError::ValidationError { details: format!("missing bytes field: {field}") })
 }
 
 #[async_trait]
@@ -235,189 +126,115 @@ impl AOClient for MockAOClient {
     async fn execute(
         &self,
         process_id: &str,
-        msg: ExecuteMsg,
-    ) -> Result<AOResponse, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() {
-            return Err(err);
-        }
-
-        if let Err(e) = msg.validate() {
-            return Err(AOCommunicationError::validation_error(e));
-        }
-
+        msg: AOExecuteMsg,
+    ) -> Result<AONativeResponse, AOCommunicationError> {
+        if let Some(err) = self.check_error_injection() { return Err(err); }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::invalid_process_id("empty process ID"));
+            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
 
-        let event = match &msg {
-            ExecuteMsg::DelegateKFrag { kfrag_id, kfrag } => {
-                self.store_kfrag(process_id, kfrag_id, kfrag.as_slice().to_vec());
-                AOEvent::with_attributes(
-                    "delegate_kfrag",
-                    vec![("kfrag_id", kfrag_id.as_str()), ("process_id", process_id)],
-                )
+        let d = &msg.data;
+        match msg.action.as_str() {
+            "DelegateKFrag" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let kfrag = data_bytes(d, "kfrag")?;
+                self.store_kfrag(process_id, kfrag_id, kfrag);
+                Ok(AONativeResponse::success(serde_json::json!({ "kfrag_id": kfrag_id, "delegated": true })))
             }
-            ExecuteMsg::DelegateCapsule {
-                kfrag_id,
-                capsule_id,
-                capsule,
-            } => {
-                self.store_capsule(
-                    process_id,
-                    kfrag_id,
-                    capsule_id,
-                    capsule.as_slice().to_vec(),
-                );
-                AOEvent::with_attributes(
-                    "delegate_capsule",
-                    vec![
-                        ("kfrag_id", kfrag_id.as_str()),
-                        ("capsule_id", capsule_id.as_str()),
-                        ("process_id", process_id),
-                    ],
-                )
+            "DelegateCapsule" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let capsule_id = data_str(d, "capsule_id")?;
+                let capsule = data_bytes(d, "capsule")?;
+                self.store_capsule(process_id, kfrag_id, capsule_id, capsule);
+                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "delegated": true })))
             }
-            ExecuteMsg::SubmitKFrag { kfrag_id, kfrag } => {
-                self.store_kfrag(process_id, kfrag_id, kfrag.as_slice().to_vec());
-                AOEvent::with_attributes(
-                    "submit_kfrag",
-                    vec![("kfrag_id", kfrag_id.as_str()), ("process_id", process_id)],
-                )
+            "SubmitKFrag" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let kfrag = data_bytes(d, "kfrag")?;
+                self.store_kfrag(process_id, kfrag_id, kfrag);
+                Ok(AONativeResponse::success(serde_json::json!({ "kfrag_id": kfrag_id, "stored": true })))
             }
-            ExecuteMsg::SubmitCapsule {
-                kfrag_id,
-                capsule_id,
-                capsule,
-            } => {
-                self.store_capsule(
-                    process_id,
-                    kfrag_id,
-                    capsule_id,
-                    capsule.as_slice().to_vec(),
-                );
-                AOEvent::with_attributes(
-                    "submit_capsule",
-                    vec![
-                        ("kfrag_id", kfrag_id.as_str()),
-                        ("capsule_id", capsule_id.as_str()),
-                        ("process_id", process_id),
-                    ],
-                )
+            "SubmitCapsule" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let capsule_id = data_str(d, "capsule_id")?;
+                let capsule = data_bytes(d, "capsule")?;
+                // Simulate re-encryption: store dummy cFrag
+                let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
+                self.store_capsule(process_id, kfrag_id, capsule_id, capsule);
+                self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
+                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true })))
             }
-            ExecuteMsg::Reencrypt {
-                kfrag_id,
-                capsule_id,
-            } => {
-                // Simulate reencryption by storing a dummy cFrag
+            "Reencrypt" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let capsule_id = data_str(d, "capsule_id")?;
                 let dummy_cfrag = format!("cfrag:{kfrag_id}:{capsule_id}").into_bytes();
                 self.store_cfrag(process_id, kfrag_id, capsule_id, dummy_cfrag);
-                AOEvent::with_attributes(
-                    "reencrypt",
-                    vec![
-                        ("kfrag_id", kfrag_id.as_str()),
-                        ("capsule_id", capsule_id.as_str()),
-                        ("process_id", process_id),
-                    ],
-                )
+                Ok(AONativeResponse::success(serde_json::json!({ "capsule_id": capsule_id, "cfrag_ready": true })))
             }
-        };
-
-        Ok(AOResponse::success_with_events(vec![event]))
+            other => Err(AOCommunicationError::ExecutionError {
+                process_id: process_id.to_string(),
+                details: format!("Unknown action: {other}"),
+            }),
+        }
     }
 
-    async fn query(&self, process_id: &str, msg: QueryMsg) -> Result<Binary, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() {
-            return Err(err);
-        }
-
-        if let Err(e) = msg.validate() {
-            return Err(AOCommunicationError::validation_error(e));
-        }
-
+    async fn query(
+        &self,
+        process_id: &str,
+        msg: AOQueryMsg,
+    ) -> Result<Binary, AOCommunicationError> {
+        if let Some(err) = self.check_error_injection() { return Err(err); }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::invalid_process_id("empty process ID"));
+            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
 
-        match &msg {
-            QueryMsg::GetCFrag {
-                kfrag_id,
-                capsule_id,
-            } => {
-                let cfrag_data = self
-                    .get_cfrag(process_id, kfrag_id, capsule_id)
-                    .ok_or_else(|| {
-                        AOCommunicationError::execution_error(process_id, "CFrag not ready")
-                    })?;
+        let d = &msg.data;
+        match msg.action.as_str() {
+            "GetCFrag" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let capsule_id = data_str(d, "capsule_id")?;
+                let cfrag_data = self.get_cfrag(process_id, kfrag_id, capsule_id).ok_or_else(|| {
+                    AOCommunicationError::ExecutionError {
+                        process_id: process_id.to_string(),
+                        details: "CFrag not ready".to_string(),
+                    }
+                })?;
                 let response = GetCFragResponse {
-                    cfrag: Binary::from(cfrag_data),
-                    meta: BlobMeta {
-                        size: 0,
-                        created_at: "2024-01-01T00:00:00Z".to_string(),
-                        content_type: Some("application/octet-stream".to_string()),
-                    },
+                    kfrag_id: kfrag_id.to_string(),
+                    capsule_id: capsule_id.to_string(),
+                    cfrag: cfrag_data,
                 };
                 let json = serde_json::to_vec(&response)
-                    .map_err(|e| AOCommunicationError::serialization_error(e.to_string()))?;
+                    .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
                 Ok(Binary::from(json))
             }
-            QueryMsg::ListCapsulesByKFrag {
-                kfrag_id,
-                start_after,
-                limit,
-            } => {
-                let capsules = self.list_capsules_by_kfrag(
-                    process_id,
-                    kfrag_id,
-                    start_after.as_deref(),
-                    *limit,
-                );
-                let last_capsule_id = capsules.last().map(|(id, _)| id.clone());
-                let response = ListCapsulesByKFragResponse {
-                    capsules: capsules
-                        .into_iter()
-                        .map(|(id, status)| CapsuleInfo {
-                            capsule_id: id,
-                            status,
-                            updated_ts: "2024-01-01T00:00:00Z".to_string(),
-                        })
-                        .collect(),
-                    next_start_after: last_capsule_id,
-                };
-                let json = serde_json::to_vec(&response)
-                    .map_err(|e| AOCommunicationError::serialization_error(e.to_string()))?;
+            "ListCapsules" => {
+                let kfrag_id = data_str(d, "kfrag_id")?;
+                let s = self.capsule_storage.read().unwrap();
+                let capsule_ids: Vec<String> = s.get(process_id)
+                    .map(|m| m.iter().filter(|(_, (kid, _))| kid == kfrag_id).map(|(cid, _)| cid.clone()).collect())
+                    .unwrap_or_default();
+                let json = serde_json::to_vec(&serde_json::json!({ "kfrag_id": kfrag_id, "capsule_ids": capsule_ids }))
+                    .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
                 Ok(Binary::from(json))
             }
+            other => Err(AOCommunicationError::ExecutionError {
+                process_id: process_id.to_string(),
+                details: format!("Unknown query action: {other}"),
+            }),
         }
     }
 
     async fn dry_run(
         &self,
         process_id: &str,
-        msg: ExecuteMsg,
-    ) -> Result<AOResponse, AOCommunicationError> {
-        if let Some(err) = self.check_error_injection() {
-            return Err(err);
-        }
-
-        if let Err(e) = msg.validate() {
-            return Err(AOCommunicationError::validation_error(e));
-        }
-
+        msg: AOExecuteMsg,
+    ) -> Result<AONativeResponse, AOCommunicationError> {
+        if let Some(err) = self.check_error_injection() { return Err(err); }
         if process_id.is_empty() {
-            return Err(AOCommunicationError::invalid_process_id("empty process ID"));
+            return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
-
-        // Dry run simulates execution without persisting changes
-        let event_type = match &msg {
-            ExecuteMsg::DelegateKFrag { .. } => "dry_run:delegate_kfrag",
-            ExecuteMsg::DelegateCapsule { .. } => "dry_run:delegate_capsule",
-            ExecuteMsg::SubmitKFrag { .. } => "dry_run:submit_kfrag",
-            ExecuteMsg::SubmitCapsule { .. } => "dry_run:submit_capsule",
-            ExecuteMsg::Reencrypt { .. } => "dry_run:reencrypt",
-        };
-
-        Ok(AOResponse::success_with_events(vec![
-            AOEvent::with_attributes(event_type, vec![("process_id", process_id)]),
-        ]))
+        // Dry-run: simulate without side-effects
+        Ok(AONativeResponse::success(serde_json::json!({ "dry_run": true, "action": msg.action })))
     }
 }

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -24,6 +24,8 @@ use crate::adapter::external::ao::{
 pub struct MockConfig {
     pub delay_ms: Option<u64>,
     pub fail_rate: Option<f64>,
+    /// If true, next `execute()` call returns `ok: false` response instead of success.
+    pub force_ok_false: bool,
 }
 
 /// Type alias: process_id -> (capsule_id -> (kfrag_id, capsule_data))
@@ -37,6 +39,8 @@ pub struct MockAOClient {
     #[allow(dead_code)]
     config: MockConfig,
     error_injection: RwLock<Option<AOCommunicationError>>,
+    /// When Some, next execute() returns AONativeResponse { ok: false, error: msg }
+    ok_false_injection: RwLock<Option<String>>,
 }
 
 impl MockAOClient {
@@ -47,6 +51,7 @@ impl MockAOClient {
             capsule_storage: RwLock::new(HashMap::new()),
             config: MockConfig::default(),
             error_injection: RwLock::new(None),
+            ok_false_injection: RwLock::new(None),
         }
     }
     pub fn with_config(config: MockConfig) -> Self {
@@ -56,6 +61,7 @@ impl MockAOClient {
             capsule_storage: RwLock::new(HashMap::new()),
             config,
             error_injection: RwLock::new(None),
+            ok_false_injection: RwLock::new(None),
         }
     }
 
@@ -64,6 +70,10 @@ impl MockAOClient {
     }
     pub fn clear_error(&self) {
         *self.error_injection.write().unwrap() = None;
+    }
+    /// Makes the next `execute()` call return `ok: false` with the given reason.
+    pub fn inject_ok_false(&self, reason: impl Into<String>) {
+        *self.ok_false_injection.write().unwrap() = Some(reason.into());
     }
 
     pub fn get_stored_kfrags(&self, process_id: &str) -> Vec<(String, Vec<u8>)> {
@@ -86,6 +96,9 @@ impl MockAOClient {
 
     fn check_error_injection(&self) -> Option<AOCommunicationError> {
         self.error_injection.write().unwrap().take()
+    }
+    fn check_ok_false_injection(&self) -> Option<String> {
+        self.ok_false_injection.write().unwrap().take()
     }
     fn store_kfrag(&self, process_id: &str, kfrag_id: &str, data: Vec<u8>) {
         self.kfrag_storage.write().unwrap().entry(process_id.to_string()).or_default().insert(kfrag_id.to_string(), data);
@@ -148,6 +161,9 @@ impl AOClient for MockAOClient {
         msg: AOExecuteMsg,
     ) -> Result<AONativeResponse, AOCommunicationError> {
         if let Some(err) = self.check_error_injection() { return Err(err); }
+        if let Some(reason) = self.check_ok_false_injection() {
+            return Ok(AONativeResponse::error_response(reason));
+        }
         if process_id.is_empty() {
             return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
@@ -227,7 +243,7 @@ impl AOClient for MockAOClient {
                     .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
                 Ok(Binary::from(json))
             }
-            "ListCapsulesByKFrag" => {
+            "ListCapsules" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 // Optional pagination params
                 let start_after = d.get("start_after").and_then(|v| v.as_str());

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -114,11 +114,30 @@ fn data_str<'a>(data: &'a serde_json::Value, field: &str) -> Result<&'a str, AOC
         AOCommunicationError::ValidationError { details: format!("missing field: {field}") }
     })
 }
-/// Extract bytes from `msg.data[field]` (JSON array of u8 values).
+/// Extract bytes from `msg.data[field]` (JSON array of u8 values, 0..=255).
+/// Returns an error if the field is missing, not an array, or contains out-of-range values.
 fn data_bytes(data: &serde_json::Value, field: &str) -> Result<Vec<u8>, AOCommunicationError> {
-    data.get(field).and_then(|v| v.as_array()).map(|arr| {
-        arr.iter().filter_map(|v| v.as_u64()).map(|n| n as u8).collect()
-    }).ok_or_else(|| AOCommunicationError::ValidationError { details: format!("missing bytes field: {field}") })
+    let arr = data
+        .get(field)
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| AOCommunicationError::ValidationError {
+            details: format!("missing or non-array field: {field}"),
+        })?;
+
+    arr.iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let n = v.as_u64().ok_or_else(|| AOCommunicationError::ValidationError {
+                details: format!("field {field}[{i}] is not a number"),
+            })?;
+            if n > 255 {
+                return Err(AOCommunicationError::ValidationError {
+                    details: format!("field {field}[{i}] = {n} is out of u8 range (0..=255)"),
+                });
+            }
+            Ok(n as u8)
+        })
+        .collect()
 }
 
 #[async_trait]
@@ -210,12 +229,34 @@ impl AOClient for MockAOClient {
             }
             "ListCapsulesByKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
+                // Optional pagination params
+                let start_after = d.get("start_after").and_then(|v| v.as_str());
+                let limit = d.get("limit").and_then(|v| v.as_u64()).unwrap_or(100) as usize;
+
                 let s = self.capsule_storage.read().unwrap();
-                let capsule_ids: Vec<String> = s.get(process_id)
-                    .map(|m| m.iter().filter(|(_, (kid, _))| kid == kfrag_id).map(|(cid, _)| cid.clone()).collect())
+                let mut capsule_ids: Vec<String> = s.get(process_id)
+                    .map(|m| m.iter()
+                        .filter(|(_, (kid, _))| kid.as_str() == kfrag_id)
+                        .map(|(cid, _)| cid.clone())
+                        .collect())
                     .unwrap_or_default();
-                let json = serde_json::to_vec(&serde_json::json!({ "kfrag_id": kfrag_id, "capsule_ids": capsule_ids }))
-                    .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
+
+                // Deterministic order + pagination (matches production contract behaviour)
+                capsule_ids.sort();
+                if let Some(start) = start_after {
+                    capsule_ids.retain(|id| id.as_str() > start);
+                }
+                capsule_ids.truncate(limit);
+                let next_start_after = capsule_ids.last().cloned();
+
+                // Response format mirrors the production contract:
+                // { kfrag_id, capsule_ids, next_start_after }
+                let json = serde_json::to_vec(&serde_json::json!({
+                    "kfrag_id": kfrag_id,
+                    "capsule_ids": capsule_ids,
+                    "next_start_after": next_start_after,
+                }))
+                .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
                 Ok(Binary::from(json))
             }
             other => Err(AOCommunicationError::ExecutionError {

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -1,7 +1,7 @@
 //! Mock AO Network client (updated for HyperBEAM-native message types)
 //!
 //! Implements `AOClient` from `ao/` using `AOExecuteMsg`/`AOQueryMsg`/`AONativeResponse`.
-//! All business logic dispatches on `msg.action` string instead of enum variants.
+//! All business logic dispatches on `msg.action()` string instead of enum variants.
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::disallowed_names)]
@@ -133,8 +133,8 @@ impl AOClient for MockAOClient {
             return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
 
-        let d = &msg.data;
-        match msg.action.as_str() {
+        let d = msg.data();
+        match msg.action() {
             "DelegateKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let kfrag = data_bytes(d, "kfrag")?;
@@ -188,8 +188,8 @@ impl AOClient for MockAOClient {
             return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
 
-        let d = &msg.data;
-        match msg.action.as_str() {
+        let d = msg.data();
+        match msg.action() {
             "GetCFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let capsule_id = data_str(d, "capsule_id")?;
@@ -208,7 +208,7 @@ impl AOClient for MockAOClient {
                     .map_err(|e| AOCommunicationError::SerializationError { details: e.to_string() })?;
                 Ok(Binary::from(json))
             }
-            "ListCapsules" => {
+            "ListCapsulesByKFrag" => {
                 let kfrag_id = data_str(d, "kfrag_id")?;
                 let s = self.capsule_storage.read().unwrap();
                 let capsule_ids: Vec<String> = s.get(process_id)
@@ -235,6 +235,6 @@ impl AOClient for MockAOClient {
             return Err(AOCommunicationError::ValidationError { details: "empty process ID".into() });
         }
         // Dry-run: simulate without side-effects
-        Ok(AONativeResponse::success(serde_json::json!({ "dry_run": true, "action": msg.action })))
+        Ok(AONativeResponse::success(serde_json::json!({ "dry_run": true, "action": msg.action() })))
     }
 }

--- a/client/src/adapter/external/mod.rs
+++ b/client/src/adapter/external/mod.rs
@@ -2,17 +2,22 @@
 //!
 //! Provides adapters for external system integrations including
 //! Arweave and AO network communication.
+//!
+//! ## AO modules
+//! - `ao/`       — HyperBEAM-native AO client (current)
+//! - `ao_cwao/`  — Legacy CosmWasm AO client (preserved for reference)
 
 pub mod ao;
+pub mod ao_cwao;
 pub mod arweave;
 pub mod mock_ao;
 
 pub use arweave::{ArweaveClientConfig, ArweaveClientImpl, ArweaveWallet};
 
+// Re-export HyperBEAM-native AO types (new default)
 pub use ao::{
-    AOAttribute, AOClient, AOConfig, AOEvent, AOMessageTags, AOResponse, Binary, BlobMeta,
-    CapsuleInfo, CapsuleStatus, ExecuteMsg, GetCFragResponse, ListCapsulesByKFragResponse,
-    QueryMsg, ValidateMessage, MAX_BINARY_SIZE, MAX_ID_LENGTH,
+    AOClient, AOConfig, AOExecuteMsg, AONativeResponse, AOQueryMsg,
+    Binary, GetCFragResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };
 #[cfg(feature = "production-ao")]
 pub use ao::{ArweaveJWK, DataItemBuilder, DataItemSigner, ProductionAOClient};

--- a/client/src/adapter/external/mod.rs
+++ b/client/src/adapter/external/mod.rs
@@ -16,8 +16,8 @@ pub use arweave::{ArweaveClientConfig, ArweaveClientImpl, ArweaveWallet};
 
 // Re-export HyperBEAM-native AO types (new default)
 pub use ao::{
-    AOClient, AOConfig, AOExecuteMsg, AONativeResponse, AOQueryMsg,
-    Binary, GetCFragResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH,
+    AOClient, AOConfig, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
+    MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };
 #[cfg(feature = "production-ao")]
 pub use ao::{ArweaveJWK, DataItemBuilder, DataItemSigner, ProductionAOClient};

--- a/client/src/adapter/mod.rs
+++ b/client/src/adapter/mod.rs
@@ -9,8 +9,8 @@ pub mod repository_impl;
 
 pub use errors::{AOCommunicationError, AOResult, AdapterError, AdapterResult};
 pub use external::{
-    AOAttribute, AOClient, AOEvent, AOMessageTags, AOResponse, Binary, ExecuteMsg, MockAOClient,
-    MockConfig, QueryMsg, ValidateMessage,
+    AOClient, AOConfig, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
+    MockAOClient, MockConfig,
 };
 pub use external::{ArweaveClientConfig, ArweaveClientImpl, ArweaveWallet};
 pub use repository_impl::{ArweaveClient, Tag};

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse};
+use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AOQueryMsg, GetCFragResponse};
 use crate::service::error::{ServiceError, ServiceResult};
 use crate::usecase::core::crypto::{CFragData, KeyFragment};
 
@@ -65,13 +65,19 @@ impl<A: AOClient> ContractStorageImpl<A> {
     ///
     /// Tracked in: PR #83 todo list.
     pub fn new(ao_client: Arc<A>, holder_process_id: impl Into<String>) -> Self {
-        Self { ao_client, holder_process_id: holder_process_id.into() }
+        Self {
+            ao_client,
+            holder_process_id: holder_process_id.into(),
+        }
     }
 
     /// Convenience constructor for single-process setups (holder = owner).
     /// Holder process ID defaults to the contract_id passed at call time.
     pub fn new_single_process(ao_client: Arc<A>) -> Self {
-        Self { ao_client, holder_process_id: String::new() }
+        Self {
+            ao_client,
+            holder_process_id: String::new(),
+        }
     }
 }
 
@@ -85,15 +91,23 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
     ) -> ServiceResult<()> {
         for kfrag in kfrags {
             let kfrag_id = format!("{secret_id}_{}", kfrag.id);
-            let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag.key_data.clone());
-            let resp = self.ao_client
+            let holder = if self.holder_process_id.is_empty() {
+                contract_id.to_string()
+            } else {
+                self.holder_process_id.clone()
+            };
+            let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag.key_data.clone(), holder);
+            let resp = self
+                .ao_client
                 .execute(contract_id, msg)
                 .await
                 .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
 
             // Guard: transport succeeded but contract returned logical error
             if !resp.ok {
-                let reason = resp.error.unwrap_or_else(|| "DelegateKFrag returned ok:false".into());
+                let reason = resp
+                    .error
+                    .unwrap_or_else(|| "DelegateKFrag returned ok:false".into());
                 return Err(ServiceError::ao_network_error(format!(
                     "kfrag_id={kfrag_id}: {reason}"
                 )));
@@ -116,15 +130,19 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
             self.holder_process_id.clone()
         };
 
-        let msg = AOExecuteMsg::delegate_capsule(kfrag_id, capsule_id, capsule_data.to_vec(), holder);
-        let resp = self.ao_client
+        let msg =
+            AOExecuteMsg::delegate_capsule(kfrag_id, capsule_id, capsule_data.to_vec(), holder);
+        let resp = self
+            .ao_client
             .execute(contract_id, msg)
             .await
             .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
 
         // Guard: transport succeeded but contract returned logical error
         if !resp.ok {
-            let reason = resp.error.unwrap_or_else(|| "DelegateCapsule returned ok:false".into());
+            let reason = resp
+                .error
+                .unwrap_or_else(|| "DelegateCapsule returned ok:false".into());
             return Err(ServiceError::ao_network_error(format!(
                 "kfrag_id={kfrag_id}, capsule_id={capsule_id}: {reason}"
             )));
@@ -149,16 +167,25 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
             match self.ao_client.query(process_id, msg).await {
                 Ok(result) => {
                     let response: GetCFragResponse = serde_json::from_slice(result.as_slice())
-                        .map_err(|e| ServiceError::ao_network_error(
-                            format!("Failed to parse cFrag for {kfrag_id}: {e}")
-                        ))?;
+                        .map_err(|e| {
+                            ServiceError::ao_network_error(format!(
+                                "Failed to parse cFrag for {kfrag_id}: {e}"
+                            ))
+                        })?;
                     cfrags.push(CFragData {
                         cfrag_data: response.cfrag,
                         holder_id: kfrag_id,
                     });
                 }
-                Err(_) => {
-                    // cFrag not yet ready for this kfrag — skip
+                Err(e) => {
+                    let msg = e.to_string();
+                    // "not ready" means cFrag hasn't been generated yet — expected, skip
+                    if msg.contains("not ready") || msg.contains("CFrag not ready") {
+                        continue;
+                    }
+                    return Err(ServiceError::ao_network_error(format!(
+                        "Failed to query cFrag for {kfrag_id}: {msg}"
+                    )));
                 }
             }
         }
@@ -171,13 +198,18 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use super::{ContractStorage, ContractStorageImpl};
     use crate::adapter::external::mock_ao::MockAOClient;
     use crate::usecase::core::crypto::KeyFragment;
-    use super::{ContractStorage, ContractStorageImpl};
+    use std::sync::Arc;
 
     fn make_kfrag(id: u8, data: Vec<u8>) -> KeyFragment {
-        KeyFragment { id, key_data: data }
+        KeyFragment {
+            id,
+            key_data: data,
+            verification_data: vec![],
+            precursor: vec![],
+        }
     }
 
     // ─── send_kfrags ─────────────────────────────────────────────────────────
@@ -188,7 +220,9 @@ mod tests {
         let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
 
         let kfrags = vec![make_kfrag(0, vec![1, 2, 3])];
-        cs.send_kfrags(&kfrags, "owner-process", "secret-1").await.unwrap();
+        cs.send_kfrags(&kfrags, "owner-process", "secret-1")
+            .await
+            .unwrap();
 
         let stored = mock.get_stored_kfrags("owner-process");
         assert_eq!(stored.len(), 1, "should store 1 kfrag at contract_id");
@@ -207,7 +241,9 @@ mod tests {
             make_kfrag(1, vec![30, 40]),
             make_kfrag(2, vec![50, 60]),
         ];
-        cs.send_kfrags(&kfrags, "owner-process", "secret-x").await.unwrap();
+        cs.send_kfrags(&kfrags, "owner-process", "secret-x")
+            .await
+            .unwrap();
 
         let stored = mock.get_stored_kfrags("owner-process");
         assert_eq!(stored.len(), 3);
@@ -224,7 +260,10 @@ mod tests {
         let result = cs.send_kfrags(&kfrags, "owner-process", "secret-1").await;
         assert!(result.is_err(), "ok:false should propagate as ServiceError");
         let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("secret-1_0"), "error should include kfrag_id");
+        assert!(
+            err_msg.contains("secret-1_0"),
+            "error should include kfrag_id"
+        );
     }
 
     // ─── delegate_capsule: holder_process_id フォールバック ──────────────────
@@ -241,7 +280,11 @@ mod tests {
 
         // Capsule should be stored at contract_id = "owner-process"
         let stored = mock.get_stored_capsules("owner-process");
-        assert_eq!(stored.len(), 1, "capsule should be at contract_id when holder unset");
+        assert_eq!(
+            stored.len(),
+            1,
+            "capsule should be at contract_id when holder unset"
+        );
         let (cap_id, kfrag_id, data) = &stored[0];
         assert_eq!(cap_id, "cap-001");
         assert_eq!(kfrag_id, "kfrag-0");
@@ -258,18 +301,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Nothing stored at owner-process
+        // Mock routes capsule to holder_process_id from the message data
         assert!(
             mock.get_stored_capsules("owner-process").is_empty(),
             "capsule should NOT be at owner-process when holder_process_id is set"
         );
-        // Capsule should be stored at holder-process (via DelegateCapsule → holder routing)
-        // NOTE: MockAOClient stores at the process_id passed to execute(), which is owner-process.
-        // The holder routing in production is done by the Owner contract emitting an OutgoingMessage.
-        // In mock, we just verify the message data contains the correct holder_process_id.
-        let stored_owner = mock.get_stored_capsules("owner-process");
-        assert_eq!(stored_owner.len(), 1);
-        let (cap_id, _, _) = &stored_owner[0];
+        let stored_holder = mock.get_stored_capsules("holder-process");
+        assert_eq!(stored_holder.len(), 1);
+        let (cap_id, _, _) = &stored_holder[0];
         assert_eq!(cap_id, "cap-001");
     }
 
@@ -341,7 +380,7 @@ mod tests {
     #[test]
     fn delegate_kfrag_action_name_matches_contract() {
         use crate::adapter::external::ao::AOExecuteMsg;
-        let msg = AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3]);
+        let msg = AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "holder-0");
         assert_eq!(msg.action(), "DelegateKFrag");
     }
 
@@ -364,5 +403,20 @@ mod tests {
         use crate::adapter::external::ao::AOQueryMsg;
         let msg = AOQueryMsg::get_cfrag("kfrag-0", "cap-001");
         assert_eq!(msg.action(), "GetCFrag");
+    }
+
+    #[test]
+    fn init_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOExecuteMsg;
+        let msg = AOExecuteMsg::init("Owner");
+        assert_eq!(msg.action(), "Init");
+    }
+
+    #[test]
+    fn delegate_kfrag_includes_holder_process_id() {
+        use crate::adapter::external::ao::AOExecuteMsg;
+        let msg = AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "holder-0");
+        let data = msg.data();
+        assert_eq!(data["holder_process_id"].as_str(), Some("holder-0"));
     }
 }

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -54,11 +54,22 @@ pub struct ContractStorageImpl<A: AOClient> {
 }
 
 impl<A: AOClient> ContractStorageImpl<A> {
+    /// Create a new ContractStorageImpl.
+    ///
+    /// # DI wiring note
+    /// This constructor signature differs from the old `ContractStorageImpl::new(ao_client)`.
+    /// `holder_process_id` was added for the HyperBEAM two-process model (Owner + Holder).
+    ///
+    /// **TODO**: Update `di.rs` (dependency injection wiring) to pass `holder_process_id`.
+    /// For single-process setups (Owner == Holder), use `new_single_process()` instead.
+    ///
+    /// Tracked in: PR #83 todo list.
     pub fn new(ao_client: Arc<A>, holder_process_id: impl Into<String>) -> Self {
         Self { ao_client, holder_process_id: holder_process_id.into() }
     }
 
     /// Convenience constructor for single-process setups (holder = owner).
+    /// Holder process ID defaults to the contract_id passed at call time.
     pub fn new_single_process(ao_client: Arc<A>) -> Self {
         Self { ao_client, holder_process_id: String::new() }
     }
@@ -75,10 +86,18 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         for kfrag in kfrags {
             let kfrag_id = format!("{secret_id}_{}", kfrag.id);
             let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag.key_data.clone());
-            self.ao_client
+            let resp = self.ao_client
                 .execute(contract_id, msg)
                 .await
                 .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
+
+            // Guard: transport succeeded but contract returned logical error
+            if !resp.ok {
+                let reason = resp.error.unwrap_or_else(|| "DelegateKFrag returned ok:false".into());
+                return Err(ServiceError::ao_network_error(format!(
+                    "kfrag_id={kfrag_id}: {reason}"
+                )));
+            }
         }
         Ok(())
     }
@@ -98,10 +117,19 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         };
 
         let msg = AOExecuteMsg::delegate_capsule(kfrag_id, capsule_id, capsule_data.to_vec(), holder);
-        self.ao_client
+        let resp = self.ao_client
             .execute(contract_id, msg)
             .await
             .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
+
+        // Guard: transport succeeded but contract returned logical error
+        if !resp.ok {
+            let reason = resp.error.unwrap_or_else(|| "DelegateCapsule returned ok:false".into());
+            return Err(ServiceError::ao_network_error(format!(
+                "kfrag_id={kfrag_id}, capsule_id={capsule_id}: {reason}"
+            )));
+        }
+
         Ok(())
     }
 

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -9,10 +9,22 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AOQueryMsg, GetCFragResponse};
 use crate::service::error::{ServiceError, ServiceResult};
 use crate::usecase::core::crypto::{CFragData, KeyFragment};
+
+/// Bincode-serializable payload matching the contract's `StoredKeyFrag` layout.
+/// The contract validates incoming kFrag bytes via `bincode::deserialize::<StoredKeyFrag>`,
+/// so the client must send the full structure — not just `key_data`.
+#[derive(Serialize, Deserialize)]
+struct StoredKeyFragPayload {
+    id: String,
+    key_data: Vec<u8>,
+    verification_data: Vec<u8>,
+    precursor: Vec<u8>,
+}
 
 /// Contract storage trait for AO Network communication.
 #[async_trait]
@@ -96,7 +108,16 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
             } else {
                 self.holder_process_id.clone()
             };
-            let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag.key_data.clone(), holder);
+            let payload = StoredKeyFragPayload {
+                id: kfrag_id.clone(),
+                key_data: kfrag.key_data.clone(),
+                verification_data: kfrag.verification_data.clone(),
+                precursor: kfrag.precursor.clone(),
+            };
+            let kfrag_bytes = bincode::serialize(&payload).map_err(|e| {
+                ServiceError::validation_error(format!("kFrag serialization failed: {e}"))
+            })?;
+            let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag_bytes, holder);
             let resp = self
                 .ao_client
                 .execute(contract_id, msg)
@@ -228,7 +249,10 @@ mod tests {
         assert_eq!(stored.len(), 1, "should store 1 kfrag at contract_id");
         let (kfrag_id, data) = &stored[0];
         assert_eq!(kfrag_id, "secret-1_0");
-        assert_eq!(data, &[1u8, 2, 3]);
+        // Stored bytes are bincode-serialized StoredKeyFragPayload
+        let decoded: super::StoredKeyFragPayload =
+            bincode::deserialize(data).expect("should deserialize as StoredKeyFragPayload");
+        assert_eq!(decoded.key_data, vec![1u8, 2, 3]);
     }
 
     #[tokio::test]

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -298,13 +298,14 @@ mod tests {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
 
-        // Pre-register kfrag so mock's holder validation passes
         use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
-        let kfrag_msg =
-            AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "owner-process");
+        let (kfrag_bytes, capsule_bytes) = create_test_crypto_data("kfrag-0");
+
+        // Pre-register kfrag with valid Umbral data
+        let kfrag_msg = AOExecuteMsg::delegate_kfrag("kfrag-0", kfrag_bytes, "owner-process");
         mock.execute("owner-process", kfrag_msg).await.unwrap();
 
-        cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
+        cs.delegate_capsule(&capsule_bytes, "owner-process", "kfrag-0", "cap-001")
             .await
             .unwrap();
 
@@ -315,10 +316,9 @@ mod tests {
             1,
             "capsule should be at contract_id when holder unset"
         );
-        let (cap_id, kfrag_id, data) = &stored[0];
+        let (cap_id, kfrag_id, _data) = &stored[0];
         assert_eq!(cap_id, "cap-001");
         assert_eq!(kfrag_id, "kfrag-0");
-        assert_eq!(data, b"capsule-data");
     }
 
     /// holder_process_id が設定済み → そのプロセスIDに送られる
@@ -327,13 +327,14 @@ mod tests {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new(Arc::clone(&mock), "holder-process");
 
-        // Pre-register kfrag so mock's holder validation passes
         use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
-        let kfrag_msg =
-            AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "holder-process");
+        let (kfrag_bytes, capsule_bytes) = create_test_crypto_data("kfrag-0");
+
+        // Pre-register kfrag with valid Umbral data
+        let kfrag_msg = AOExecuteMsg::delegate_kfrag("kfrag-0", kfrag_bytes, "holder-process");
         mock.execute("owner-process", kfrag_msg).await.unwrap();
 
-        cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
+        cs.delegate_capsule(&capsule_bytes, "owner-process", "kfrag-0", "cap-001")
             .await
             .unwrap();
 
@@ -362,14 +363,75 @@ mod tests {
 
     // ─── retrieve_cfrags ─────────────────────────────────────────────────────
 
+    /// Generate valid Umbral kFrag + Capsule test data for a given kfrag_id.
+    fn create_test_crypto_data(kfrag_id: &str) -> (Vec<u8>, Vec<u8>) {
+        use serde::Serialize as TestSerialize;
+        use umbral_pre::{DefaultSerialize, SecretKey};
+
+        #[derive(TestSerialize)]
+        struct Payload {
+            id: String,
+            key_data: Vec<u8>,
+            verification_data: Vec<u8>,
+            precursor: Vec<u8>,
+        }
+        #[derive(TestSerialize)]
+        struct VD {
+            verifying_pk: Vec<u8>,
+            delegating_pk: Vec<u8>,
+            receiving_pk: Vec<u8>,
+        }
+
+        let delegating_sk = SecretKey::random();
+        let delegating_pk = delegating_sk.public_key();
+        let receiving_sk = SecretKey::random();
+        let receiving_pk = receiving_sk.public_key();
+        let signing_sk = SecretKey::random();
+        let verifying_pk = signing_sk.public_key();
+        let signer = umbral_pre::Signer::new(signing_sk);
+
+        let (capsule, _) = umbral_pre::encrypt(&delegating_pk, b"test").unwrap();
+        let capsule_bytes = bincode::serialize(&capsule).unwrap();
+
+        let verified_kfrags =
+            umbral_pre::generate_kfrags(&delegating_sk, &receiving_pk, &signer, 1, 1, true, true);
+        let kfrag = verified_kfrags[0].clone().unverify();
+        let kfrag_data = kfrag.to_bytes().unwrap().to_vec();
+
+        let vd = VD {
+            verifying_pk: bincode::serialize(&verifying_pk).unwrap(),
+            delegating_pk: bincode::serialize(&delegating_pk).unwrap(),
+            receiving_pk: bincode::serialize(&receiving_pk).unwrap(),
+        };
+
+        let payload = Payload {
+            id: kfrag_id.to_string(),
+            key_data: kfrag_data,
+            verification_data: bincode::serialize(&vd).unwrap(),
+            precursor: vec![],
+        };
+        (bincode::serialize(&payload).unwrap(), capsule_bytes)
+    }
+
     #[tokio::test]
     async fn retrieve_cfrags_returns_ready_cfrags() {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
 
-        // Simulate re-encryption: use Reencrypt action to generate a cFrag
         use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
-        let msg = AOExecuteMsg::reencrypt("secret-1_0", "cap-001");
+        let (kfrag_bytes, capsule_bytes) = create_test_crypto_data("secret-1_0");
+
+        // DelegateKFrag → stores kfrag at holder-process
+        let msg = AOExecuteMsg::delegate_kfrag("secret-1_0", kfrag_bytes, "holder-process");
+        mock.execute("holder-process", msg).await.unwrap();
+
+        // DelegateCapsule → triggers real re-encryption → cFrag stored
+        let msg = AOExecuteMsg::delegate_capsule(
+            "secret-1_0",
+            "cap-001",
+            capsule_bytes,
+            "holder-process",
+        );
         mock.execute("holder-process", msg).await.unwrap();
 
         let cfrags = cs
@@ -385,9 +447,19 @@ mod tests {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
 
-        // total_shares=3 but only 1 cfrag exists
         use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
-        let msg = AOExecuteMsg::reencrypt("secret-1_1", "cap-001");
+        // Only create data for kfrag index 1 (out of 3)
+        let (kfrag_bytes, capsule_bytes) = create_test_crypto_data("secret-1_1");
+
+        let msg = AOExecuteMsg::delegate_kfrag("secret-1_1", kfrag_bytes, "holder-process");
+        mock.execute("holder-process", msg).await.unwrap();
+
+        let msg = AOExecuteMsg::delegate_capsule(
+            "secret-1_1",
+            "cap-001",
+            capsule_bytes,
+            "holder-process",
+        );
         mock.execute("holder-process", msg).await.unwrap();
 
         let cfrags = cs

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -166,3 +166,203 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         Ok(cfrags)
     }
 }
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use crate::adapter::external::mock_ao::MockAOClient;
+    use crate::usecase::core::crypto::KeyFragment;
+    use super::{ContractStorage, ContractStorageImpl};
+
+    fn make_kfrag(id: u8, data: Vec<u8>) -> KeyFragment {
+        KeyFragment { id, key_data: data }
+    }
+
+    // ─── send_kfrags ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_kfrags_stores_to_contract_id() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        let kfrags = vec![make_kfrag(0, vec![1, 2, 3])];
+        cs.send_kfrags(&kfrags, "owner-process", "secret-1").await.unwrap();
+
+        let stored = mock.get_stored_kfrags("owner-process");
+        assert_eq!(stored.len(), 1, "should store 1 kfrag at contract_id");
+        let (kfrag_id, data) = &stored[0];
+        assert_eq!(kfrag_id, "secret-1_0");
+        assert_eq!(data, &[1u8, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn send_kfrags_multiple_stores_all() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        let kfrags = vec![
+            make_kfrag(0, vec![10, 20]),
+            make_kfrag(1, vec![30, 40]),
+            make_kfrag(2, vec![50, 60]),
+        ];
+        cs.send_kfrags(&kfrags, "owner-process", "secret-x").await.unwrap();
+
+        let stored = mock.get_stored_kfrags("owner-process");
+        assert_eq!(stored.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn send_kfrags_ok_false_returns_error() {
+        let mock = Arc::new(MockAOClient::new());
+        // Inject ok:false for the first execute() call
+        mock.inject_ok_false("DelegateKFrag returned ok:false");
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        let kfrags = vec![make_kfrag(0, vec![1, 2, 3])];
+        let result = cs.send_kfrags(&kfrags, "owner-process", "secret-1").await;
+        assert!(result.is_err(), "ok:false should propagate as ServiceError");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("secret-1_0"), "error should include kfrag_id");
+    }
+
+    // ─── delegate_capsule: holder_process_id フォールバック ──────────────────
+
+    /// holder_process_id が未設定 (new_single_process) → contract_id にフォールバック
+    #[tokio::test]
+    async fn delegate_capsule_fallback_uses_contract_id() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
+            .await
+            .unwrap();
+
+        // Capsule should be stored at contract_id = "owner-process"
+        let stored = mock.get_stored_capsules("owner-process");
+        assert_eq!(stored.len(), 1, "capsule should be at contract_id when holder unset");
+        let (cap_id, kfrag_id, data) = &stored[0];
+        assert_eq!(cap_id, "cap-001");
+        assert_eq!(kfrag_id, "kfrag-0");
+        assert_eq!(data, b"capsule-data");
+    }
+
+    /// holder_process_id が設定済み → そのプロセスIDに送られる
+    #[tokio::test]
+    async fn delegate_capsule_uses_holder_when_set() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new(Arc::clone(&mock), "holder-process");
+
+        cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
+            .await
+            .unwrap();
+
+        // Nothing stored at owner-process
+        assert!(
+            mock.get_stored_capsules("owner-process").is_empty(),
+            "capsule should NOT be at owner-process when holder_process_id is set"
+        );
+        // Capsule should be stored at holder-process (via DelegateCapsule → holder routing)
+        // NOTE: MockAOClient stores at the process_id passed to execute(), which is owner-process.
+        // The holder routing in production is done by the Owner contract emitting an OutgoingMessage.
+        // In mock, we just verify the message data contains the correct holder_process_id.
+        let stored_owner = mock.get_stored_capsules("owner-process");
+        assert_eq!(stored_owner.len(), 1);
+        let (cap_id, _, _) = &stored_owner[0];
+        assert_eq!(cap_id, "cap-001");
+    }
+
+    #[tokio::test]
+    async fn delegate_capsule_ok_false_returns_error() {
+        let mock = Arc::new(MockAOClient::new());
+        mock.inject_ok_false("DelegateCapsule failed");
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        let result = cs
+            .delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
+            .await;
+        assert!(result.is_err());
+    }
+
+    // ─── retrieve_cfrags ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn retrieve_cfrags_returns_ready_cfrags() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        // Simulate re-encryption: use Reencrypt action to generate a cFrag
+        use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
+        let msg = AOExecuteMsg::reencrypt("secret-1_0", "cap-001");
+        mock.execute("holder-process", msg).await.unwrap();
+
+        let cfrags = cs
+            .retrieve_cfrags("secret-1", 1, "cap-001", "holder-process")
+            .await
+            .unwrap();
+        assert_eq!(cfrags.len(), 1);
+        assert_eq!(cfrags[0].holder_id, "secret-1_0");
+    }
+
+    #[tokio::test]
+    async fn retrieve_cfrags_skips_missing() {
+        let mock = Arc::new(MockAOClient::new());
+        let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
+
+        // total_shares=3 but only 1 cfrag exists
+        use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
+        let msg = AOExecuteMsg::reencrypt("secret-1_1", "cap-001");
+        mock.execute("holder-process", msg).await.unwrap();
+
+        let cfrags = cs
+            .retrieve_cfrags("secret-1", 3, "cap-001", "holder-process")
+            .await
+            .unwrap();
+        // Only the one that's ready comes back
+        assert_eq!(cfrags.len(), 1);
+    }
+
+    // ─── action名契約テスト (contract test) ──────────────────────────────────
+
+    /// コントラクト側の action 名とクライアント側が一致していることを型レベルで保証する。
+    /// このテストが通れば、action 名ズレによる silent failure を防止できる。
+    #[test]
+    fn list_capsules_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOQueryMsg;
+        let msg = AOQueryMsg::list_capsules_by_kfrag("kfrag-0", None, None);
+        assert_eq!(
+            msg.action(),
+            "ListCapsules",
+            "action name must match ao/contracts/src/handlers.rs dispatch table"
+        );
+    }
+
+    #[test]
+    fn delegate_kfrag_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOExecuteMsg;
+        let msg = AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3]);
+        assert_eq!(msg.action(), "DelegateKFrag");
+    }
+
+    #[test]
+    fn delegate_capsule_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOExecuteMsg;
+        let msg = AOExecuteMsg::delegate_capsule("kfrag-0", "cap-001", vec![1, 2], "holder");
+        assert_eq!(msg.action(), "DelegateCapsule");
+    }
+
+    #[test]
+    fn reencrypt_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOExecuteMsg;
+        let msg = AOExecuteMsg::reencrypt("kfrag-0", "cap-001");
+        assert_eq!(msg.action(), "Reencrypt");
+    }
+
+    #[test]
+    fn get_cfrag_action_name_matches_contract() {
+        use crate::adapter::external::ao::AOQueryMsg;
+        let msg = AOQueryMsg::get_cfrag("kfrag-0", "cap-001");
+        assert_eq!(msg.action(), "GetCFrag");
+    }
+}

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -174,7 +174,7 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
                         })?;
                     cfrags.push(CFragData {
                         cfrag_data: response.cfrag,
-                        holder_id: kfrag_id,
+                        holder_id: process_id.to_string(),
                     });
                 }
                 Err(e) => {
@@ -274,6 +274,12 @@ mod tests {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new_single_process(Arc::clone(&mock));
 
+        // Pre-register kfrag so mock's holder validation passes
+        use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
+        let kfrag_msg =
+            AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "owner-process");
+        mock.execute("owner-process", kfrag_msg).await.unwrap();
+
         cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
             .await
             .unwrap();
@@ -296,6 +302,12 @@ mod tests {
     async fn delegate_capsule_uses_holder_when_set() {
         let mock = Arc::new(MockAOClient::new());
         let cs = ContractStorageImpl::new(Arc::clone(&mock), "holder-process");
+
+        // Pre-register kfrag so mock's holder validation passes
+        use crate::adapter::external::ao::{AOClient, AOExecuteMsg};
+        let kfrag_msg =
+            AOExecuteMsg::delegate_kfrag("kfrag-0", vec![1, 2, 3], "holder-process");
+        mock.execute("owner-process", kfrag_msg).await.unwrap();
 
         cs.delegate_capsule(b"capsule-data", "owner-process", "kfrag-0", "cap-001")
             .await
@@ -341,7 +353,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cfrags.len(), 1);
-        assert_eq!(cfrags[0].holder_id, "secret-1_0");
+        assert_eq!(cfrags[0].holder_id, "holder-process");
     }
 
     #[tokio::test]

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -1,22 +1,23 @@
-//! ContractStorage - AO contract communication service
+//! ContractStorage - AO contract communication service (HyperBEAM-native)
 //!
-//! Handles AO Network contract interactions, separated from
-//! Arweave immutable storage operations for clean SRP compliance.
+//! Updated for new `ao/` module:
+//! - `ExecuteMsg::*` enum variants → `AOExecuteMsg::*` builder methods
+//! - `QueryMsg::*` → `AOQueryMsg::*` builder methods
+//! - `AOResponse` → `AONativeResponse`
+//! - `GetCFragResponse` parses `{ kfrag_id, capsule_id, cfrag: [u8] }` format
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::adapter::external::ao::{AOClient, Binary, ExecuteMsg, GetCFragResponse, QueryMsg};
+use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse};
 use crate::service::error::{ServiceError, ServiceResult};
 use crate::usecase::core::crypto::{CFragData, KeyFragment};
 
-/// Contract storage trait for AO Network communication
+/// Contract storage trait for AO Network communication.
 #[async_trait]
 pub trait ContractStorage: Send + Sync {
-    /// Send kFrags to Owner-Process via AO Network
-    ///
-    /// kfrag_id is formatted as `{secret_id}_{index}` to bind kFrags to a secret.
+    /// Send kFrags to Owner-Process via AO Network.
     async fn send_kfrags(
         &self,
         kfrags: &[KeyFragment],
@@ -24,17 +25,7 @@ pub trait ContractStorage: Send + Sync {
         secret_id: &str,
     ) -> ServiceResult<()>;
 
-    /// Delegate capsule to AO contract for re-encryption triggering
-    ///
-    /// Associates the Arweave capsule with its kFrag so the AO contract
-    /// can trigger Phase 2 re-encryption.
-    ///
-    /// # Arguments
-    /// * `capsule_data` - Serialized capsule bytes (from Arweave CapsulePayload)
-    /// * `contract_id` - Owner-Process contract ID on AO Network
-    /// * `kfrag_id`    - kFrag identifier matching the corresponding DelegateKFrag call
-    ///                   (format: `"kfrag-{index}"`)
-    /// * `capsule_id`  - Arweave transaction ID of the stored capsule (`capsule_tx_id`)
+    /// Delegate capsule to AO contract for re-encryption triggering.
     async fn delegate_capsule(
         &self,
         capsule_data: &[u8],
@@ -43,10 +34,7 @@ pub trait ContractStorage: Send + Sync {
         capsule_id: &str,
     ) -> ServiceResult<()>;
 
-    /// Retrieve cFrags for a secret from AO Network
-    ///
-    /// Generates kfrag_ids from `{secret_id}_{0..total_shares}` convention,
-    /// then queries each kfrag's cFrag individually via GetCFrag.
+    /// Retrieve cFrags for a secret from AO Network.
     async fn retrieve_cfrags(
         &self,
         secret_id: &str,
@@ -56,14 +44,23 @@ pub trait ContractStorage: Send + Sync {
     ) -> ServiceResult<Vec<CFragData>>;
 }
 
-/// ContractStorage implementation using AOClient
+/// ContractStorage implementation using AOClient (HyperBEAM-native).
 pub struct ContractStorageImpl<A: AOClient> {
     ao_client: Arc<A>,
+    /// Default holder process ID for DelegateCapsule.
+    /// In HyperBEAM, Owner-Process delegates to a Holder-Process via AO message.
+    /// Set to the same process_id for single-process setups.
+    holder_process_id: String,
 }
 
 impl<A: AOClient> ContractStorageImpl<A> {
-    pub fn new(ao_client: Arc<A>) -> Self {
-        Self { ao_client }
+    pub fn new(ao_client: Arc<A>, holder_process_id: impl Into<String>) -> Self {
+        Self { ao_client, holder_process_id: holder_process_id.into() }
+    }
+
+    /// Convenience constructor for single-process setups (holder = owner).
+    pub fn new_single_process(ao_client: Arc<A>) -> Self {
+        Self { ao_client, holder_process_id: String::new() }
     }
 }
 
@@ -76,16 +73,13 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         secret_id: &str,
     ) -> ServiceResult<()> {
         for kfrag in kfrags {
-            let msg = ExecuteMsg::DelegateKFrag {
-                kfrag_id: format!("{secret_id}_{}", kfrag.id),
-                kfrag: Binary::from(kfrag.key_data.clone()),
-            };
+            let kfrag_id = format!("{secret_id}_{}", kfrag.id);
+            let msg = AOExecuteMsg::delegate_kfrag(&kfrag_id, kfrag.key_data.clone());
             self.ao_client
                 .execute(contract_id, msg)
                 .await
                 .map_err(|e| ServiceError::ao_network_error(e.to_string()))?;
         }
-
         Ok(())
     }
 
@@ -96,11 +90,14 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         kfrag_id: &str,
         capsule_id: &str,
     ) -> ServiceResult<()> {
-        let msg = ExecuteMsg::DelegateCapsule {
-            kfrag_id: kfrag_id.to_string(),
-            capsule_id: capsule_id.to_string(),
-            capsule: Binary::from(capsule_data.to_vec()),
+        // holder_process_id defaults to contract_id for single-process setups
+        let holder = if self.holder_process_id.is_empty() {
+            contract_id.to_string()
+        } else {
+            self.holder_process_id.clone()
         };
+
+        let msg = AOExecuteMsg::delegate_capsule(kfrag_id, capsule_id, capsule_data.to_vec(), holder);
         self.ao_client
             .execute(contract_id, msg)
             .await
@@ -119,21 +116,16 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
 
         for i in 0..total_shares {
             let kfrag_id = format!("{secret_id}_{i}");
-            let msg = QueryMsg::GetCFrag {
-                kfrag_id: kfrag_id.clone(),
-                capsule_id: capsule_id.to_string(),
-            };
+            let msg = AOQueryMsg::get_cfrag(&kfrag_id, capsule_id);
 
             match self.ao_client.query(process_id, msg).await {
                 Ok(result) => {
                     let response: GetCFragResponse = serde_json::from_slice(result.as_slice())
-                        .map_err(|e| {
-                            ServiceError::ao_network_error(format!(
-                                "Failed to parse cFrag response for {kfrag_id}: {e}"
-                            ))
-                        })?;
+                        .map_err(|e| ServiceError::ao_network_error(
+                            format!("Failed to parse cFrag for {kfrag_id}: {e}")
+                        ))?;
                     cfrags.push(CFragData {
-                        cfrag_data: response.cfrag.as_slice().to_vec(),
+                        cfrag_data: response.cfrag,
                         holder_id: kfrag_id,
                     });
                 }

--- a/client/src/usecase/workflow/container.rs
+++ b/client/src/usecase/workflow/container.rs
@@ -84,7 +84,7 @@ impl DefaultWorkflowServiceContainer {
 
         let mock_ao = Arc::new(MockAOClient::new());
         let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-        let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+        let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
         let storage_service = Arc::new(StorageServiceImpl::new(arweave, contract));
 
         Self::new(crypto_service, storage_service)
@@ -102,7 +102,7 @@ pub fn create_secret_sharing_service() -> impl SecretSharingWorkflowService {
 
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage_service = Arc::new(StorageServiceImpl::new(arweave, contract));
 
     SecretSharingWorkflowServiceImpl::new(crypto_service, storage_service)
@@ -115,7 +115,7 @@ pub fn create_secret_recovery_service() -> impl SecretRecoveryWorkflowService {
 
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage_service = Arc::new(StorageServiceImpl::new(arweave, contract));
 
     SecretRecoveryWorkflowServiceImpl::new(crypto_service, storage_service)
@@ -131,7 +131,7 @@ pub fn create_workflow_services() -> (
 
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage_service = Arc::new(StorageServiceImpl::new(arweave, contract));
 
     let sharing = SecretSharingWorkflowServiceImpl::new(

--- a/client/src/usecase/workflow/secret_sharing_service.rs
+++ b/client/src/usecase/workflow/secret_sharing_service.rs
@@ -360,7 +360,8 @@ impl<C: CryptoService, ST: StorageService> SecretSharingWorkflowService
         let mut delegate_failed_ids: Vec<(String, String)> = Vec::new();
 
         for kfrag in &kfrags {
-            let kfrag_id = format!("kfrag-{}", kfrag.id);
+            // Must match the format used in send_kfrags: {secret_id}_{index}
+            let kfrag_id = format!("{}_{}", secret_id.as_str(), kfrag.id);
             let mut last_err: Option<String> = None;
 
             for attempt in 0..=DELEGATE_CAPSULE_MAX_RETRIES {

--- a/client/tests/integration/actions_integration_test.rs
+++ b/client/tests/integration/actions_integration_test.rs
@@ -20,7 +20,7 @@ use formix::usecase::dto::SecretMetadata;
 fn create_test_container() -> DefaultActionsContainer {
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     DefaultActionsContainer::with_storage(arweave, contract)
 }
 

--- a/client/tests/integration/builder_api_test.rs
+++ b/client/tests/integration/builder_api_test.rs
@@ -12,7 +12,7 @@ use formix::usecase::dto::SecretMetadata;
 fn default_client() -> FormixClient {
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     FormixClient::with_storage(
         "test_process".to_string(),
         "test_wallet".to_string(),

--- a/client/tests/integration/secret_recovery_workflow_test.rs
+++ b/client/tests/integration/secret_recovery_workflow_test.rs
@@ -34,7 +34,7 @@ fn create_integration_service(
     let crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     SecretRecoveryWorkflowServiceImpl::new(crypto, storage)
 }
@@ -218,7 +218,7 @@ async fn test_phase3_integration_execute_fails_at_storage() {
     let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     let service = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage);
 
@@ -276,7 +276,7 @@ async fn test_phase3_integration_validation_errors() {
     let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     let service = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage);
 

--- a/client/tests/integration/secret_sharing_workflow_test.rs
+++ b/client/tests/integration/secret_sharing_workflow_test.rs
@@ -29,7 +29,7 @@ fn create_integration_service(
     let crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     SecretSharingWorkflowServiceImpl::new(crypto, storage)
 }
@@ -144,7 +144,7 @@ fn test_phase1_integration_crypto_operations_valid() {
     let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     let _service = SecretSharingWorkflowServiceImpl::new(service_crypto, storage);
 

--- a/client/tests/integration/workflow_roundtrip_test.rs
+++ b/client/tests/integration/workflow_roundtrip_test.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use zeroize::Zeroizing;
 
 use formix::adapter::external::mock_ao::MockAOClient;
+use formix::domain::value_objects::SecretId;
 use formix::usecase::core::contract_storage::ContractStorageImpl;
 use formix::usecase::core::crypto::{
     CFragData, CryptoService, CryptoServiceImpl as CoreCryptoServiceImpl, ShamirShare,
@@ -21,8 +22,11 @@ use formix::usecase::core::storage::ArweaveStorageServiceImpl;
 use formix::usecase::service::{
     CryptoServiceImpl as ServiceCryptoServiceImpl, StorageServiceImpl as ServiceStorageServiceImpl,
 };
-use formix::usecase::workflow::{SecretSharingWorkflowService, SecretSharingWorkflowServiceImpl};
-use formix::usecase::SecretSharingRequest;
+use formix::usecase::workflow::{
+    SecretRecoveryWorkflowService, SecretRecoveryWorkflowServiceImpl, SecretSharingWorkflowService,
+    SecretSharingWorkflowServiceImpl,
+};
+use formix::usecase::{SecretRecoveryRequest, SecretSharingRequest};
 
 // ============================================================================
 // PHASE 1 → PHASE 3 Roundtrip Tests (Task 22)
@@ -642,4 +646,215 @@ fn test_full_pre_roundtrip_phase1_phase2_phase3() {
     println!("  [PASS] AES-encrypted secret also decrypted correctly");
 
     println!("\n[PASS] Full PRE roundtrip Phase 1 → Phase 2 → Phase 3 successful!");
+}
+
+// ============================================================================
+// E2E Tests: Phase 1 → Phase 2 → Phase 3 via Workflow Services (GAP-5)
+// ============================================================================
+
+/// Wire up both sharing and recovery workflow services with shared MockAOClient + Arweave.
+fn setup_e2e_services() -> (
+    Arc<CoreCryptoServiceImpl>,
+    SecretSharingWorkflowServiceImpl<
+        ServiceCryptoServiceImpl<CoreCryptoServiceImpl>,
+        ServiceStorageServiceImpl<ArweaveStorageServiceImpl, ContractStorageImpl<MockAOClient>>,
+    >,
+    SecretRecoveryWorkflowServiceImpl<
+        ServiceCryptoServiceImpl<CoreCryptoServiceImpl>,
+        ServiceStorageServiceImpl<ArweaveStorageServiceImpl, ContractStorageImpl<MockAOClient>>,
+    >,
+) {
+    let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
+    let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
+    let mock_ao = Arc::new(MockAOClient::new());
+    let arweave = Arc::new(ArweaveStorageServiceImpl::default());
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
+    let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
+
+    let sharing =
+        SecretSharingWorkflowServiceImpl::new(Arc::clone(&service_crypto), Arc::clone(&storage));
+    let recovery = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage);
+
+    (core_crypto, sharing, recovery)
+}
+
+/// Happy path: Phase 1 → Phase 2 (auto) → Phase 3, k=3, n=5.
+/// Verifies that the recovered secret equals the original byte-for-byte.
+#[tokio::test]
+async fn test_e2e_full_pipeline_phase1_to_phase3() {
+    let (core_crypto, sharing, recovery) = setup_e2e_services();
+
+    let (owner_sk, owner_pk) = core_crypto.generate_keypair().unwrap();
+    let (requester_sk, requester_pk) = core_crypto.generate_keypair().unwrap();
+
+    let original_secret = b"E2E happy-path test secret (k=3, n=5)!";
+    let secret_data: Vec<u8> = original_secret.to_vec();
+    let owner_process_id = "e2e-owner-process";
+
+    // ── Phase 1 ──
+    let phase1 = sharing
+        .execute_secret_sharing(SecretSharingRequest {
+            secret: Zeroizing::new(secret_data.clone()),
+            owner_secret_key: owner_sk,
+            owner_public_key: owner_pk.clone(),
+            requester_public_key: requester_pk,
+            threshold: 3,
+            total_shares: 5,
+            owner_process_id: owner_process_id.to_string(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(phase1.kfrag_count, 5);
+    assert_eq!(phase1.share_tx_ids.len(), 5);
+
+    // ── Phase 2 is automatic (MockAOClient performs real Umbral re-encryption) ──
+
+    // ── Phase 3 ──
+    let phase3 = recovery
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: phase1.secret_id,
+            requester_secret_key: requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: owner_process_id.to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(phase3.recovered_secret, secret_data);
+}
+
+/// Error case: fewer cFrags than threshold → InsufficientCFrags.
+///
+/// Uses a fresh MockAOClient where no cFrags exist for the kfrag_ids,
+/// so Phase 3 retrieves 0 cFrags against k=3.
+#[tokio::test]
+async fn test_e2e_threshold_not_met() {
+    let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
+    let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
+    let mock_ao_phase1 = Arc::new(MockAOClient::new());
+    let arweave = Arc::new(ArweaveStorageServiceImpl::default());
+    let contract_phase1 = Arc::new(ContractStorageImpl::new_single_process(Arc::clone(
+        &mock_ao_phase1,
+    )));
+    let storage_phase1 = Arc::new(ServiceStorageServiceImpl::new(
+        Arc::clone(&arweave),
+        contract_phase1,
+    ));
+
+    let (owner_sk, owner_pk) = core_crypto.generate_keypair().unwrap();
+    let (requester_sk, requester_pk) = core_crypto.generate_keypair().unwrap();
+
+    let owner_process_id = "e2e-threshold-owner";
+    let original_secret = b"Threshold test secret";
+
+    // Phase 1: share normally
+    let sharing = SecretSharingWorkflowServiceImpl::new(
+        Arc::clone(&service_crypto),
+        Arc::clone(&storage_phase1),
+    );
+    let phase1 = sharing
+        .execute_secret_sharing(SecretSharingRequest {
+            secret: Zeroizing::new(original_secret.to_vec()),
+            owner_secret_key: owner_sk,
+            owner_public_key: owner_pk.clone(),
+            requester_public_key: requester_pk,
+            threshold: 3,
+            total_shares: 5,
+            owner_process_id: owner_process_id.to_string(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    // Phase 3: use a NEW MockAOClient that has NO cFrags
+    let mock_ao_empty = Arc::new(MockAOClient::new());
+    let contract_empty = Arc::new(ContractStorageImpl::new_single_process(mock_ao_empty));
+    let storage_empty = Arc::new(ServiceStorageServiceImpl::new(arweave, contract_empty));
+    let recovery = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage_empty);
+
+    let result = recovery
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: phase1.secret_id,
+            requester_secret_key: requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: owner_process_id.to_string(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("Insufficient") || err_msg.contains("insufficient"),
+        "Expected InsufficientCFrags error, got: {err_msg}"
+    );
+}
+
+/// Error case: wrong requester secret key → PRE decryption failure.
+#[tokio::test]
+async fn test_e2e_wrong_requester_key() {
+    let (core_crypto, sharing, recovery) = setup_e2e_services();
+
+    let (owner_sk, owner_pk) = core_crypto.generate_keypair().unwrap();
+    let (_correct_requester_sk, requester_pk) = core_crypto.generate_keypair().unwrap();
+    let (wrong_requester_sk, _) = core_crypto.generate_keypair().unwrap();
+
+    let owner_process_id = "e2e-wrong-key-owner";
+
+    let phase1 = sharing
+        .execute_secret_sharing(SecretSharingRequest {
+            secret: Zeroizing::new(b"Wrong key test secret".to_vec()),
+            owner_secret_key: owner_sk,
+            owner_public_key: owner_pk.clone(),
+            requester_public_key: requester_pk,
+            threshold: 3,
+            total_shares: 5,
+            owner_process_id: owner_process_id.to_string(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let result = recovery
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: phase1.secret_id,
+            requester_secret_key: wrong_requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: owner_process_id.to_string(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("decrypt") || err_msg.contains("Decrypt") || err_msg.contains("PRE"),
+        "Expected decryption error, got: {err_msg}"
+    );
+}
+
+/// Error case: non-existent secret → Capsule not found.
+#[tokio::test]
+async fn test_e2e_capsule_not_found() {
+    let (core_crypto, _sharing, recovery) = setup_e2e_services();
+
+    let (requester_sk, _) = core_crypto.generate_keypair().unwrap();
+    let (_, owner_pk) = core_crypto.generate_keypair().unwrap();
+
+    let result = recovery
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: SecretId::new("nonexistent-secret-id"),
+            requester_secret_key: requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: "e2e-notfound-process".to_string(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found") || err_msg.contains("Not found"),
+        "Expected not-found error, got: {err_msg}"
+    );
 }

--- a/client/tests/integration/workflow_roundtrip_test.rs
+++ b/client/tests/integration/workflow_roundtrip_test.rs
@@ -398,7 +398,7 @@ async fn test_roundtrip_workflow_services_integration() {
     let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     let sharing_service = SecretSharingWorkflowServiceImpl::new(service_crypto, storage);
 

--- a/client/tests/unit/actions/container.rs
+++ b/client/tests/unit/actions/container.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroizing;
 fn create_test_container() -> DefaultActionsContainer {
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     DefaultActionsContainer::with_storage(arweave, contract)
 }
 

--- a/client/tests/unit/actions/di.rs
+++ b/client/tests/unit/actions/di.rs
@@ -77,7 +77,7 @@ fn test_container_with_dependencies() {
 
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage_service = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
 
     let controller = ControllerContainer::new(Arc::clone(&crypto_service));

--- a/client/tests/unit/adapter/external/ao/message.rs
+++ b/client/tests/unit/adapter/external/ao/message.rs
@@ -1,6 +1,5 @@
 use formix::adapter::external::ao::{
-    AOEvent, AOMessageTags, AOResponse, Binary, CapsuleStatus, ExecuteMsg, QueryMsg,
-    ValidateMessage,
+    AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
 };
 
 #[test]
@@ -28,186 +27,97 @@ fn test_binary_serialization() {
 }
 
 #[test]
-fn test_execute_msg_delegate_kfrag_serialization() {
-    let msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "kfrag-001".to_string(),
-        kfrag: Binary::new(vec![1, 2, 3, 4]),
-    };
-
-    let json = serde_json::to_string(&msg).unwrap();
-    assert!(json.contains("kfrag_id"));
-
-    let deserialized: ExecuteMsg = serde_json::from_str(&json).unwrap();
-    assert_eq!(msg, deserialized);
+fn test_ao_execute_msg_delegate_kfrag() {
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-001", vec![1, 2, 3, 4], "holder-1");
+    assert_eq!(msg.action(), "DelegateKFrag");
+    assert_eq!(msg.data()["kfrag_id"].as_str(), Some("kfrag-001"));
+    assert_eq!(msg.data()["holder_process_id"].as_str(), Some("holder-1"));
 }
 
 #[test]
-fn test_execute_msg_delegate_capsule_serialization() {
-    let msg = ExecuteMsg::DelegateCapsule {
-        kfrag_id: "kfrag-001".to_string(),
-        capsule_id: "capsule-001".to_string(),
-        capsule: Binary::new(vec![5, 6, 7, 8]),
-    };
-
-    let json = serde_json::to_string(&msg).unwrap();
-    assert!(json.contains("capsule_id"));
-
-    let deserialized: ExecuteMsg = serde_json::from_str(&json).unwrap();
-    assert_eq!(msg, deserialized);
+fn test_ao_execute_msg_delegate_capsule() {
+    let msg =
+        AOExecuteMsg::delegate_capsule("kfrag-001", "capsule-001", vec![5, 6, 7, 8], "holder-1");
+    assert_eq!(msg.action(), "DelegateCapsule");
+    assert_eq!(msg.data()["capsule_id"].as_str(), Some("capsule-001"));
+    assert_eq!(msg.data()["holder_process_id"].as_str(), Some("holder-1"));
 }
 
 #[test]
-fn test_query_msg_get_cfrag_serialization() {
-    let msg = QueryMsg::GetCFrag {
-        kfrag_id: "kfrag-001".to_string(),
-        capsule_id: "capsule-001".to_string(),
-    };
-
-    let json = serde_json::to_string(&msg).unwrap();
-    assert!(json.contains("kfrag_id"));
-
-    let deserialized: QueryMsg = serde_json::from_str(&json).unwrap();
-    assert_eq!(msg, deserialized);
+fn test_ao_execute_msg_reencrypt() {
+    let msg = AOExecuteMsg::reencrypt("kfrag-001", "capsule-001");
+    assert_eq!(msg.action(), "Reencrypt");
+    assert_eq!(msg.data()["kfrag_id"].as_str(), Some("kfrag-001"));
+    assert_eq!(msg.data()["capsule_id"].as_str(), Some("capsule-001"));
 }
 
 #[test]
-fn test_query_msg_list_capsules_serialization() {
-    let msg = QueryMsg::ListCapsulesByKFrag {
-        kfrag_id: "kfrag-001".to_string(),
-        start_after: Some("capsule-000".to_string()),
-        limit: Some(10),
-    };
-
-    let json = serde_json::to_string(&msg).unwrap();
-    assert!(json.contains("kfrag_id"));
-
-    let deserialized: QueryMsg = serde_json::from_str(&json).unwrap();
-    assert_eq!(msg, deserialized);
+fn test_ao_execute_msg_init() {
+    let msg = AOExecuteMsg::init("Owner");
+    assert_eq!(msg.action(), "Init");
+    assert_eq!(msg.data()["role"].as_str(), Some("Owner"));
 }
 
 #[test]
-fn test_validate_execute_msg_delegate_kfrag() {
-    let valid_msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "valid-kfrag-id".to_string(),
-        kfrag: Binary::new(vec![1, 2, 3]),
-    };
-    assert!(valid_msg.validate().is_ok());
-
-    let empty_id_msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "".to_string(),
-        kfrag: Binary::new(vec![1, 2, 3]),
-    };
-    assert!(empty_id_msg.validate().is_err());
-
-    let empty_data_msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "valid-kfrag-id".to_string(),
-        kfrag: Binary::new(vec![]),
-    };
-    assert!(empty_data_msg.validate().is_err());
+fn test_ao_query_msg_get_cfrag() {
+    let msg = AOQueryMsg::get_cfrag("kfrag-001", "capsule-001");
+    assert_eq!(msg.action(), "GetCFrag");
+    assert_eq!(msg.data()["kfrag_id"].as_str(), Some("kfrag-001"));
+    assert_eq!(msg.data()["capsule_id"].as_str(), Some("capsule-001"));
 }
 
 #[test]
-fn test_validate_query_msg_list_capsules() {
-    let valid_msg = QueryMsg::ListCapsulesByKFrag {
-        kfrag_id: "valid-kfrag-id".to_string(),
-        start_after: None,
-        limit: Some(50),
-    };
-    assert!(valid_msg.validate().is_ok());
-
-    let invalid_limit_zero = QueryMsg::ListCapsulesByKFrag {
-        kfrag_id: "valid-kfrag-id".to_string(),
-        start_after: None,
-        limit: Some(0),
-    };
-    assert!(invalid_limit_zero.validate().is_err());
-
-    let invalid_limit_over = QueryMsg::ListCapsulesByKFrag {
-        kfrag_id: "valid-kfrag-id".to_string(),
-        start_after: None,
-        limit: Some(101),
-    };
-    assert!(invalid_limit_over.validate().is_err());
+fn test_ao_query_msg_list_capsules() {
+    let msg =
+        AOQueryMsg::list_capsules_by_kfrag("kfrag-001", Some("cap-000".to_string()), Some(10));
+    assert_eq!(msg.action(), "ListCapsules");
+    assert_eq!(msg.data()["kfrag_id"].as_str(), Some("kfrag-001"));
+    assert_eq!(msg.data()["start_after"].as_str(), Some("cap-000"));
 }
 
 #[test]
-fn test_ao_response_creation() {
-    let response = AOResponse::success();
-    assert!(response.success);
+fn test_ao_native_response_success() {
+    let response = AONativeResponse::success(serde_json::json!({"key": "value"}));
+    assert!(response.ok);
+    assert!(response.data.is_some());
+    assert!(response.error.is_none());
+}
+
+#[test]
+fn test_ao_native_response_error() {
+    let response = AONativeResponse::error_response("something failed");
+    assert!(!response.ok);
     assert!(response.data.is_none());
-    assert!(response.events.is_empty());
-
-    let response_with_data = AOResponse::success_with_data(Binary::new(vec![1, 2, 3]));
-    assert!(response_with_data.success);
-    assert!(response_with_data.data.is_some());
-
-    let event = AOEvent::new("kfrag_delegated");
-    let response_with_events = AOResponse::success_with_events(vec![event]);
-    assert_eq!(response_with_events.events.len(), 1);
+    assert_eq!(response.error, Some("something failed".to_string()));
 }
 
 #[test]
-fn test_ao_event_creation() {
-    let mut event = AOEvent::new("test_event");
-    event.add_attribute("key1", "value1");
-    event.add_attribute("key2", "value2");
-
-    assert_eq!(event.event_type, "test_event");
-    assert_eq!(event.attributes.len(), 2);
-    assert_eq!(event.attributes[0].key, "key1");
-    assert_eq!(event.attributes[0].value, "value1");
+fn test_get_cfrag_response_serialization() {
+    let response = GetCFragResponse {
+        kfrag_id: "kfrag-001".to_string(),
+        capsule_id: "capsule-001".to_string(),
+        cfrag: vec![1, 2, 3, 4],
+    };
+    let json = serde_json::to_string(&response).unwrap();
+    let deserialized: GetCFragResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.kfrag_id, "kfrag-001");
+    assert_eq!(deserialized.cfrag, vec![1, 2, 3, 4]);
 }
 
 #[test]
-fn test_ao_event_with_attributes() {
-    let event = AOEvent::with_attributes(
-        "kfrag_delegated",
-        vec![("kfrag_id", "kfrag-001"), ("process_id", "proc-001")],
-    );
-
-    assert_eq!(event.event_type, "kfrag_delegated");
-    assert_eq!(event.attributes.len(), 2);
+fn test_ao_execute_msg_serialization_roundtrip() {
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-001", vec![1, 2, 3], "holder-1");
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(json.contains("DelegateKFrag"));
+    let deserialized: AOExecuteMsg = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.action(), "DelegateKFrag");
 }
 
 #[test]
-fn test_ao_message_tags_execute() {
-    let tags = AOMessageTags::new_execute(
-        "DelegateKFrag",
-        r#"{"kfrag_id":"test"}"#,
-        "process-001",
-        "actor-001",
-        "2024-01-01T00:00:00Z",
-    );
-
-    assert_eq!(tags.app_name, "cwao");
-    assert_eq!(tags.action, "DelegateKFrag");
-    assert_eq!(tags.read_only, "False");
-    assert!(!tags.is_read_only());
-}
-
-#[test]
-fn test_ao_message_tags_query() {
-    let tags = AOMessageTags::new_query(
-        "GetCFrag",
-        r#"{"kfrag_id":"test"}"#,
-        "process-001",
-        "actor-001",
-        "2024-01-01T00:00:00Z",
-    );
-
-    assert_eq!(tags.app_name, "cwao");
-    assert_eq!(tags.action, "GetCFrag");
-    assert_eq!(tags.read_only, "True");
-    assert!(tags.is_read_only());
-}
-
-#[test]
-fn test_capsule_status_serialization() {
-    let status = CapsuleStatus::Pending;
-    let json = serde_json::to_string(&status).unwrap();
-    assert_eq!(json, "\"pending\"");
-
-    let status = CapsuleStatus::Reencrypted;
-    let json = serde_json::to_string(&status).unwrap();
-    assert_eq!(json, "\"reencrypted\"");
+fn test_ao_query_msg_serialization_roundtrip() {
+    let msg = AOQueryMsg::get_cfrag("kfrag-001", "capsule-001");
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(json.contains("GetCFrag"));
+    let deserialized: AOQueryMsg = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.action(), "GetCFrag");
 }

--- a/client/tests/unit/adapter/external/mock_ao/client.rs
+++ b/client/tests/unit/adapter/external/mock_ao/client.rs
@@ -6,10 +6,78 @@
 )]
 
 use formix::adapter::errors::AOCommunicationError;
-use formix::adapter::external::ao::{
-    AOClient, Binary, ExecuteMsg, GetCFragResponse, ListCapsulesByKFragResponse, QueryMsg,
-};
+use formix::adapter::external::ao::{AOClient, AOExecuteMsg, AOQueryMsg, Binary, GetCFragResponse};
 use formix::adapter::external::mock_ao::MockAOClient;
+
+/// Test data bundle containing valid Umbral crypto material for re-encryption tests.
+struct TestCryptoData {
+    /// bincode-serialized StoredKeyFragPayload (what DelegateKFrag receives)
+    kfrag_bytes: Vec<u8>,
+    /// kFrag identifier
+    kfrag_id: String,
+    /// Raw Capsule bytes (what DelegateCapsule receives)
+    capsule_bytes: Vec<u8>,
+}
+
+/// Generate valid Umbral kFrag + Capsule test data for re-encryption.
+fn create_test_kfrag_and_capsule() -> TestCryptoData {
+    use serde::Serialize;
+    use umbral_pre::{DefaultSerialize, SecretKey};
+
+    #[derive(Serialize)]
+    struct StoredKeyFragPayload {
+        id: String,
+        key_data: Vec<u8>,
+        verification_data: Vec<u8>,
+        precursor: Vec<u8>,
+    }
+    #[derive(Serialize)]
+    struct VerificationData {
+        verifying_pk: Vec<u8>,
+        delegating_pk: Vec<u8>,
+        receiving_pk: Vec<u8>,
+    }
+
+    let delegating_sk = SecretKey::random();
+    let delegating_pk = delegating_sk.public_key();
+    let receiving_sk = SecretKey::random();
+    let receiving_pk = receiving_sk.public_key();
+    let signing_sk = SecretKey::random();
+    let verifying_pk = signing_sk.public_key();
+    let signer = umbral_pre::Signer::new(signing_sk);
+
+    // Encrypt test plaintext to get a Capsule
+    let plaintext = b"test-data-for-reencryption";
+    let (capsule, _ciphertext) = umbral_pre::encrypt(&delegating_pk, plaintext).unwrap();
+    let capsule_bytes = bincode::serialize(&capsule).unwrap();
+
+    // Generate kFrags (k=1, n=1 for simple tests)
+    let verified_kfrags =
+        umbral_pre::generate_kfrags(&delegating_sk, &receiving_pk, &signer, 1, 1, true, true);
+    let kfrag = verified_kfrags[0].clone().unverify();
+    let kfrag_data = kfrag.to_bytes().unwrap().to_vec();
+
+    let vd = VerificationData {
+        verifying_pk: bincode::serialize(&verifying_pk).unwrap(),
+        delegating_pk: bincode::serialize(&delegating_pk).unwrap(),
+        receiving_pk: bincode::serialize(&receiving_pk).unwrap(),
+    };
+    let vd_bytes = bincode::serialize(&vd).unwrap();
+
+    let payload = StoredKeyFragPayload {
+        id: "kfrag-1".to_string(),
+        key_data: kfrag_data,
+        verification_data: vd_bytes,
+        precursor: vec![],
+    };
+    let kfrag_bytes = bincode::serialize(&payload).unwrap();
+
+    TestCryptoData {
+        kfrag_bytes,
+        kfrag_id: "kfrag-1".to_string(),
+        capsule_bytes,
+    }
+}
 
 #[tokio::test]
 async fn test_mock_ao_client_new() {
@@ -20,18 +88,13 @@ async fn test_mock_ao_client_new() {
 #[tokio::test]
 async fn test_execute_delegate_kfrag() {
     let client = MockAOClient::new();
-    let msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "kfrag-1".to_string(),
-        kfrag: Binary::from(vec![1, 2, 3, 4]),
-    };
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3, 4], "holder-1");
 
     let result = client.execute("process-1", msg).await;
     assert!(result.is_ok());
 
     let response = result.unwrap();
-    assert!(response.success);
-    assert_eq!(response.events.len(), 1);
-    assert_eq!(response.events[0].event_type, "delegate_kfrag");
+    assert!(response.ok);
 
     let stored = client.get_stored_kfrags("process-1");
     assert_eq!(stored.len(), 1);
@@ -40,101 +103,86 @@ async fn test_execute_delegate_kfrag() {
 }
 
 #[tokio::test]
-async fn test_execute_delegate_capsule() {
+async fn test_execute_delegate_capsule_with_reencryption() {
     let client = MockAOClient::new();
-    let msg = ExecuteMsg::DelegateCapsule {
-        kfrag_id: "kfrag-1".to_string(),
-        capsule_id: "capsule-1".to_string(),
-        capsule: Binary::from(vec![5, 6, 7, 8]),
-    };
+    let td = create_test_kfrag_and_capsule();
 
+    // Step 1: DelegateKFrag
+    let msg = AOExecuteMsg::delegate_kfrag(&td.kfrag_id, td.kfrag_bytes, "holder-1");
+    let result = client.execute("process-1", msg).await;
+    assert!(result.is_ok());
+
+    // Step 2: DelegateCapsule — triggers real re-encryption
+    let msg =
+        AOExecuteMsg::delegate_capsule(&td.kfrag_id, "capsule-1", td.capsule_bytes, "holder-1");
     let result = client.execute("process-1", msg).await;
     assert!(result.is_ok());
 
     let response = result.unwrap();
-    assert!(response.success);
-    assert_eq!(response.events[0].event_type, "delegate_capsule");
+    assert!(response.ok);
 
-    let stored = client.get_stored_capsules("process-1");
+    // Verify capsule was stored at holder process
+    let stored = client.get_stored_capsules("holder-1");
     assert_eq!(stored.len(), 1);
     assert_eq!(stored[0].0, "capsule-1");
-    assert_eq!(stored[0].1, "kfrag-1");
+
+    // Verify cFrag was generated via real Umbral re-encryption
+    let cfrags = client.get_stored_cfrags("holder-1");
+    assert_eq!(cfrags.len(), 1);
 }
 
 #[tokio::test]
 async fn test_execute_reencrypt() {
     let client = MockAOClient::new();
+    let td = create_test_kfrag_and_capsule();
 
-    let _ = client
-        .execute(
-            "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
-        )
-        .await;
+    // Store kfrag at process-1
+    let msg = AOExecuteMsg::delegate_kfrag(&td.kfrag_id, td.kfrag_bytes, "holder-1");
+    client.execute("process-1", msg).await.unwrap();
 
-    let _ = client
-        .execute(
-            "process-1",
-            ExecuteMsg::DelegateCapsule {
-                kfrag_id: "kfrag-1".to_string(),
-                capsule_id: "capsule-1".to_string(),
-                capsule: Binary::from(vec![4, 5, 6]),
-            },
-        )
-        .await;
+    // Store capsule at process-1 (Reencrypt looks up both from same process)
+    let msg = AOExecuteMsg::delegate_capsule(
+        &td.kfrag_id,
+        "capsule-1",
+        td.capsule_bytes.clone(),
+        "process-1",
+    );
+    client.execute("process-1", msg).await.unwrap();
 
+    // Reencrypt on process-1
     let result = client
         .execute(
             "process-1",
-            ExecuteMsg::Reencrypt {
-                kfrag_id: "kfrag-1".to_string(),
-                capsule_id: "capsule-1".to_string(),
-            },
+            AOExecuteMsg::reencrypt(&td.kfrag_id, "capsule-1"),
         )
         .await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
-    assert_eq!(response.events[0].event_type, "reencrypt");
+    assert!(response.ok);
 
     let cfrags = client.get_stored_cfrags("process-1");
-    assert_eq!(cfrags.len(), 1);
+    assert!(cfrags.len() >= 1);
 }
 
 #[tokio::test]
 async fn test_query_get_cfrag() {
     let client = MockAOClient::new();
+    let td = create_test_kfrag_and_capsule();
 
-    let _ = client
-        .execute(
-            "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
-        )
-        .await;
+    // DelegateKFrag + DelegateCapsule → triggers re-encryption → cFrag stored
+    let msg = AOExecuteMsg::delegate_kfrag(&td.kfrag_id, td.kfrag_bytes, "process-1");
+    client.execute("process-1", msg).await.unwrap();
 
-    let _ = client
-        .execute(
-            "process-1",
-            ExecuteMsg::Reencrypt {
-                kfrag_id: "kfrag-1".to_string(),
-                capsule_id: "capsule-1".to_string(),
-            },
-        )
-        .await;
+    let msg =
+        AOExecuteMsg::delegate_capsule(&td.kfrag_id, "capsule-1", td.capsule_bytes, "process-1");
+    client.execute("process-1", msg).await.unwrap();
 
+    // Query the generated cFrag
     let result = client
         .query(
             "process-1",
-            QueryMsg::GetCFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                capsule_id: "capsule-1".to_string(),
-            },
+            AOQueryMsg::get_cfrag(&td.kfrag_id, "capsule-1"),
         )
         .await;
 
@@ -149,13 +197,7 @@ async fn test_query_get_cfrag_not_found() {
     let client = MockAOClient::new();
 
     let result = client
-        .query(
-            "process-1",
-            QueryMsg::GetCFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                capsule_id: "capsule-1".to_string(),
-            },
-        )
+        .query("process-1", AOQueryMsg::get_cfrag("kfrag-1", "capsule-1"))
         .await;
 
     assert!(result.is_err());
@@ -167,50 +209,41 @@ async fn test_query_get_cfrag_not_found() {
 async fn test_query_list_capsules_by_kfrag() {
     let client = MockAOClient::new();
 
-    for i in 1..=5 {
-        let _ = client
-            .execute(
-                "process-1",
-                ExecuteMsg::DelegateCapsule {
-                    kfrag_id: "kfrag-1".to_string(),
-                    capsule_id: format!("capsule-{i}"),
-                    capsule: Binary::from(vec![i as u8]),
-                },
-            )
-            .await;
+    // Pre-register kfrag
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "process-1");
+    client.execute("process-1", msg).await.unwrap();
+
+    for i in 1..=5u8 {
+        let msg =
+            AOExecuteMsg::delegate_capsule("kfrag-1", format!("capsule-{i}"), vec![i], "process-1");
+        // Will fail re-encryption (dummy kfrag), but capsule still gets stored
+        let _ = client.execute("process-1", msg).await;
     }
 
     let result = client
         .query(
             "process-1",
-            QueryMsg::ListCapsulesByKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                start_after: None,
-                limit: Some(3),
-            },
+            AOQueryMsg::list_capsules_by_kfrag("kfrag-1", None, Some(3)),
         )
         .await;
 
     assert!(result.is_ok());
     let binary = result.unwrap();
-    let response: ListCapsulesByKFragResponse = serde_json::from_slice(binary.as_slice()).unwrap();
-    assert_eq!(response.capsules.len(), 3);
+    let value: serde_json::Value = serde_json::from_slice(binary.as_slice()).unwrap();
+    let capsule_ids = value["capsule_ids"].as_array().unwrap();
+    assert_eq!(capsule_ids.len(), 3);
 }
 
 #[tokio::test]
 async fn test_dry_run() {
     let client = MockAOClient::new();
-    let msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "kfrag-1".to_string(),
-        kfrag: Binary::from(vec![1, 2, 3, 4]),
-    };
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3, 4], "holder-1");
 
     let result = client.dry_run("process-1", msg).await;
     assert!(result.is_ok());
 
     let response = result.unwrap();
-    assert!(response.success);
-    assert_eq!(response.events[0].event_type, "dry_run:delegate_kfrag");
+    assert!(response.ok);
 
     let stored = client.get_stored_kfrags("process-1");
     assert!(stored.is_empty());
@@ -224,10 +257,7 @@ async fn test_error_injection() {
     let result = client
         .execute(
             "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1"),
         )
         .await;
 
@@ -238,13 +268,11 @@ async fn test_error_injection() {
         panic!("Expected ConnectionError");
     }
 
+    // Error injection is one-shot
     let result2 = client
         .execute(
             "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1"),
         )
         .await;
     assert!(result2.is_ok());
@@ -259,10 +287,7 @@ async fn test_clear_error() {
     let result = client
         .execute(
             "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1"),
         )
         .await;
 
@@ -270,14 +295,11 @@ async fn test_clear_error() {
 }
 
 #[tokio::test]
-async fn test_validation_error() {
+async fn test_empty_process_id_error() {
     let client = MockAOClient::new();
-    let msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "".to_string(),
-        kfrag: Binary::from(vec![1, 2, 3]),
-    };
+    let msg = AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1");
 
-    let result = client.execute("process-1", msg).await;
+    let result = client.execute("", msg).await;
     assert!(result.is_err());
     assert!(matches!(
         result,
@@ -286,34 +308,16 @@ async fn test_validation_error() {
 }
 
 #[tokio::test]
-async fn test_empty_process_id_error() {
-    let client = MockAOClient::new();
-    let msg = ExecuteMsg::DelegateKFrag {
-        kfrag_id: "kfrag-1".to_string(),
-        kfrag: Binary::from(vec![1, 2, 3]),
-    };
-
-    let result = client.execute("", msg).await;
-    assert!(result.is_err());
-    assert!(matches!(
-        result,
-        Err(AOCommunicationError::InvalidProcessId { .. })
-    ));
-}
-
-#[tokio::test]
 async fn test_clear_storage() {
     let client = MockAOClient::new();
 
-    let _ = client
+    client
         .execute(
             "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1"),
         )
-        .await;
+        .await
+        .unwrap();
 
     assert!(!client.get_stored_kfrags("process-1").is_empty());
 
@@ -326,25 +330,21 @@ async fn test_clear_storage() {
 async fn test_multiple_processes() {
     let client = MockAOClient::new();
 
-    let _ = client
+    client
         .execute(
             "process-1",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-1".to_string(),
-                kfrag: Binary::from(vec![1, 2, 3]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-1", vec![1, 2, 3], "holder-1"),
         )
-        .await;
+        .await
+        .unwrap();
 
-    let _ = client
+    client
         .execute(
             "process-2",
-            ExecuteMsg::DelegateKFrag {
-                kfrag_id: "kfrag-2".to_string(),
-                kfrag: Binary::from(vec![4, 5, 6]),
-            },
+            AOExecuteMsg::delegate_kfrag("kfrag-2", vec![4, 5, 6], "holder-2"),
         )
-        .await;
+        .await
+        .unwrap();
 
     let kfrags1 = client.get_stored_kfrags("process-1");
     let kfrags2 = client.get_stored_kfrags("process-2");

--- a/client/tests/unit/usecase/workflow/secret_recovery_service.rs
+++ b/client/tests/unit/usecase/workflow/secret_recovery_service.rs
@@ -25,7 +25,7 @@ fn create_test_service() -> SecretRecoveryWorkflowServiceImpl<TestCryptoService,
 
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
 
     SecretRecoveryWorkflowServiceImpl::new(crypto, storage)

--- a/client/tests/unit/usecase/workflow/secret_sharing_service.rs
+++ b/client/tests/unit/usecase/workflow/secret_sharing_service.rs
@@ -25,7 +25,7 @@ fn create_test_service() -> SecretSharingWorkflowServiceImpl<TestCryptoService, 
     let crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
     let mock_ao = Arc::new(MockAOClient::new());
     let arweave = Arc::new(ArweaveStorageServiceImpl::default());
-    let contract = Arc::new(ContractStorageImpl::new(mock_ao));
+    let contract = Arc::new(ContractStorageImpl::new_single_process(mock_ao));
     let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
     SecretSharingWorkflowServiceImpl::new(crypto, storage)
 }

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -37,10 +37,10 @@ Proxy Re-Encryption により、データ所有者の秘密鍵を一切露出す
 | --- | ----------------- | ------------------------------------------- | ---- |
 | 2-1 | **Owner-Process** | RandAOを利用してn個のHolder-Processを選出 | 分散選択 |
 | 2-2 | **Owner-Process** | 各Holder-Processに `kFragⱼ` と署名を送信 | 配布 |
-| 2-3 | **Holder-Process** | `kFragⱼ` を受信・検証してArweaveに保存 | 永続化 |
-| 2-4 | **Holder-Process** | Arweaveから `Capsuleₒ` を取得 | 準備完了 |
+| 2-3 | **Holder-Process** | `kFragⱼ` を受信・検証してWASMメモリスナップショットに保存 | HyperBEAMが自動永続化 |
+| 2-4 | **Owner-Process** | `DelegateCapsule` メッセージで `Capsuleₒ` をHolder-Processにpush | Owner→Holder push |
 | 2-5 | **Holder-Process** | `cFragⱼ = PRE_ReEnc(kFragⱼ, Capsuleₒ)` 実行 | 再暗号化 |
-| 2-6 | **Holder-Process** | `cFragⱼ` をArweaveに保存 | 永続化 |
+| 2-6 | **Holder-Process** | `cFragⱼ` をWASMメモリスナップショットに保存 | HyperBEAMが自動永続化 |
 
 **PHASE 3 秘密の復元**
 

--- a/docs/contracts/hyperbeam_contract_guide.md
+++ b/docs/contracts/hyperbeam_contract_guide.md
@@ -1,0 +1,334 @@
+# HyperBEAM コントラクト開発ガイド
+
+`ao/contracts/src/` — HyperBEAM 初心者向けのコード解説。
+
+---
+
+## 全体像: 5ファイルの役割
+
+```
+ao/contracts/src/
+├── lib.rs              ← エントリポイント（HyperBEAM が呼ぶ関数）
+├── message.rs          ← 入出力の型定義（JSON ↔ Rust）
+├── state.rs            ← プロセスの状態（メモリ上に永続化）
+├── handlers.rs         ← ビジネスロジック（9つのアクション）
+└── getrandom_impl.rs   ← 乱数（WASM 用 placeholder）
+```
+
+---
+
+## 1. lib.rs — HyperBEAM との接点
+
+HyperBEAM は「WASM バイナリの中の特定の関数を呼ぶ」ことでコントラクトを実行する。Web サーバーでいう「HTTP リクエストを受けて JSON を返す」のと似ている。
+
+```
+HyperBEAM                          WASM コントラクト
+─────────                          ──────────────────
+1. alloc(size) で領域確保      →    メモリを確保して ptr を返す
+2. ptr にメッセージ JSON を書く
+3. handle(ptr, len) を呼ぶ      →    JSON をパース → 処理 → 結果を内部バッファに書く
+4. response_len() で長さ取得    →    バッファの長さを返す
+5. 返されたポインタから読む     ←    レスポンス JSON
+6. dealloc(ptr, size) で解放    →    メモリを解放
+```
+
+```rust
+// lib.rs のコア部分（簡略化）
+
+// ─── グローバル状態（HyperBEAM がメモリごとスナップショットする） ───
+static PROCESS_STATE: SyncCell<Option<ProcessState>> = ...;
+static RESPONSE_BUF: SyncCell<Vec<u8>> = ...;
+
+// ─── HyperBEAM が呼ぶ4つの関数 ───
+pub extern "C" fn alloc(size: i32) -> i32          // メモリ確保
+pub extern "C" fn handle(ptr: i32, len: i32) -> i32 // メイン処理
+pub extern "C" fn response_len() -> i32             // レスポンス長
+pub extern "C" fn dealloc(ptr: i32, size: i32)      // メモリ解放
+```
+
+**ポイント**: `handle` の中で JSON をパースし、`handlers::dispatch` に渡すだけ。ルーティングのフロントコントローラー的な役割。
+
+---
+
+## 2. message.rs — メッセージの型
+
+Web API でいう「リクエスト/レスポンスの型定義」にあたる。
+
+```rust
+// ─── 入力（HyperBEAM → コントラクト）───
+pub struct AOMessage {
+    pub action: String,              // "DelegateKFrag", "GetCFrag" 等
+    pub from: Option<String>,        // 送信者のアドレス
+    pub id: Option<String>,          // メッセージID
+    pub data: Option<serde_json::Value>,  // アクション固有のペイロード
+}
+
+// ─── 出力（コントラクト → HyperBEAM）───
+pub struct AOResponse {
+    pub ok: bool,                    // 成功/失敗
+    pub data: Option<Value>,         // 成功時のレスポンスデータ
+    pub error: Option<String>,       // 失敗時のエラーメッセージ
+    pub messages: Vec<OutgoingMessage>,  // 他プロセスへの転送メッセージ
+}
+
+// ─── 他プロセスへの転送 ───
+pub struct OutgoingMessage {
+    pub target: String,   // 送信先プロセスID
+    pub action: String,   // 転送するアクション名
+    pub data: Value,      // 転送するデータ
+}
+```
+
+**Web API との対比**:
+
+| Web API | AO コントラクト |
+|---------|----------------|
+| HTTP Method (GET/POST) | `action` フィールド |
+| Request Body | `data` フィールド |
+| Response JSON | `AOResponse` |
+| Webhook (別サーバーに通知) | `OutgoingMessage` |
+
+---
+
+## 3. state.rs — メモリ上の永続状態
+
+Web サーバーでいう「データベース」にあたるが、全部インメモリの HashMap。
+
+```rust
+pub struct ProcessState {
+    // ─── 初期化情報 ───
+    pub role: Option<ProcessRole>,   // Owner / Holder / Requester / Combined
+    pub owner_id: Option<String>,    // 初期化した人のアドレス（認可に使用）
+
+    // ─── Owner 側のデータ ───
+    pub owner_kfrags: HashMap<String, Vec<u8>>,
+    //   "secret-1_0" → [bincode bytes...]
+    //   鍵フラグメントのバイト列
+
+    pub kfrag_holders: HashMap<String, String>,
+    //   "secret-1_0" → "holder-process-xyz"
+    //   どの kFrag をどの Holder に委任したか
+
+    // ─── Capsule 管理 ───
+    pub owner_capsules: HashMap<String, OwnerCapsuleData>,
+    //   "9:secret-1_0/cap-001" → { capsule_bytes, status, ... }
+    //   暗号化カプセルとその処理状態
+
+    pub kfrag_to_caps: HashMap<String, Vec<String>>,
+    //   "secret-1_0" → ["cap-001", "cap-002"]
+    //   kFrag に紐づく capsule ID の逆引きインデックス
+
+    // ─── Holder 側のデータ ───
+    pub holder_cfrags: HashMap<String, Vec<u8>>,
+    //   "9:secret-1_0/cap-001" → [cfrag bytes...]
+    //   再暗号化で生成された cFrag
+}
+```
+
+### データの流れ
+
+```
+DelegateKFrag で入る         DelegateCapsule で入る       再暗号化で生成
+─────────────────          ────────────────────        ────────────────
+owner_kfrags               owner_capsules              holder_cfrags
+┌─────────┬──────┐        ┌──────────┬──────────┐    ┌──────────┬──────┐
+│kfrag_id │bytes │        │cap_key   │status    │    │cap_key   │cfrag │
+├─────────┼──────┤        ├──────────┼──────────┤    ├──────────┼──────┤
+│secret_0 │[...]│   →    │s_0/cap01 │Received  │ → │s_0/cap01 │[...]│
+│secret_1 │[...]│        │s_0/cap01 │CFragReady│    │          │      │
+└─────────┴──────┘        └──────────┴──────────┘    └──────────┴──────┘
+
+kfrag_holders              kfrag_to_caps
+┌─────────┬──────────┐    ┌─────────┬────────────┐
+│kfrag_id │holder_pid│    │kfrag_id │capsule_ids │
+├─────────┼──────────┤    ├─────────┼────────────┤
+│secret_0 │holder-A  │    │secret_0 │[cap01,cap02]│
+└─────────┴──────────┘    └─────────┴────────────┘
+```
+
+### Capsule のステータス遷移
+
+```
+Received → ReencInProgress → CFragReady
+                           → Error(msg)
+```
+
+### セキュリティ関連の型
+
+```rust
+// kFrag の中間デシリアライズ用。使用後にメモリがゼロ化される
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct StoredKeyFrag {
+    pub id: String,
+    pub key_data: Vec<u8>,           // Umbral KeyFrag のバイト列
+    pub verification_data: Vec<u8>,  // 検証用公開鍵データ
+    pub precursor: Vec<u8>,          // 将来拡張用
+}
+
+// cFrag の中間デシリアライズ用
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct StoredCFrag {
+    pub fragment_data: Vec<u8>,
+}
+```
+
+---
+
+## 4. handlers.rs — ビジネスロジック
+
+Web API でいう「コントローラー + サービス層」。`dispatch` 関数がルーター、各 `handle_*` がハンドラー。
+
+### ルーティング
+
+```rust
+pub fn dispatch(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+    // 未初期化なら Init のみ受付
+    if msg.action == "Init" { return handle_init(state, msg); }
+    if !state.is_initialized() { return error("send Init first"); }
+
+    // ロールに応じてアクションを許可
+    match (role, msg.action.as_str()) {
+        // Owner/Combined のみ
+        (Owner | Combined, "DelegateKFrag")   => handle_delegate_kfrag(state, msg),
+        (Owner | Combined, "DelegateCapsule") => handle_delegate_capsule(state, msg),
+
+        // Holder/Combined のみ
+        (Holder | Combined, "SubmitKFrag")    => handle_submit_kfrag(state, msg),
+        (Holder | Combined, "SubmitCapsule")  => handle_submit_capsule(state, msg),
+        (Holder | Combined, "Reencrypt")      => handle_reencrypt(state, msg),
+
+        // 全ロール（Query）
+        (_, "GetCFrag")      => handle_get_cfrag(state, msg),
+        (_, "ListCapsules")  => handle_list_capsules(state, msg),
+
+        _ => error("Action not permitted for role"),
+    }
+}
+```
+
+### 各ハンドラーの処理概要
+
+| ハンドラー | やること | 認可 | 冪等 |
+|------------|----------|------|------|
+| `handle_init` | ロール設定 + owner_id 登録 | from が必須 | No (二重初期化は拒否) |
+| `handle_delegate_kfrag` | kFrag 保存 + Holder に SubmitKFrag 転送 | owner_id 一致 | No |
+| `handle_delegate_capsule` | Capsule 保存 + Holder に SubmitCapsule 転送 | owner_id 一致 | No |
+| `handle_submit_kfrag` | bincode 検証 → kFrag 保存 | owner_id 一致 | **Yes** (既存なら skip) |
+| `handle_submit_capsule` | Capsule 保存 → **即座に再暗号化** | owner_id 一致 | **Yes** (cFrag 既存なら skip) |
+| `handle_reencrypt` | 既存 Capsule の再暗号化リトライ | owner_id 一致 | No |
+| `handle_get_cfrag` | cFrag を返す | 認可不要 | - |
+| `handle_list_capsules` | kFrag に紐づく capsule ID 一覧 | 認可不要 | - |
+
+### 再暗号化の中身 (`perform_reencryption`)
+
+最も重要な関数。Umbral PRE の再暗号化をオンチェーンで実行する。
+
+```
+入力: kfrag_bytes (bincode), capsule_bytes
+
+Step 1: bincode::deserialize → StoredKeyFrag
+Step 2: key_data / verification_data の空チェック
+Step 3: verification_data → VerificationData { verifying_pk, delegating_pk, receiving_pk }
+Step 4: 各公開鍵を bincode デシリアライズ
+Step 5: KeyFrag::from_bytes → key_frag.verify(verifying_pk, delegating_pk, receiving_pk)
+        → 検証失敗なら拒否（改竄検知）
+Step 6: Capsule::from_bytes
+Step 7: umbral_pre::reencrypt(&capsule, verified_kfrag) → cFrag 生成
+Step 8: cFrag を bincode シリアライズして返す
+```
+
+---
+
+## 5. getrandom_impl.rs — WASM 用乱数
+
+WASM 環境には OS の `/dev/urandom` がないため、`getrandom` crate のカスタム実装が必要。
+
+```rust
+getrandom::register_custom_getrandom!(ao_getrandom);
+
+pub fn ao_getrandom(buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    // ⚠️ 決定論的な placeholder — 本番では使用不可
+    for (i, byte) in buf.iter_mut().enumerate() {
+        *byte = (i as u8).wrapping_mul(7).wrapping_add(42);
+    }
+    Ok(())
+}
+```
+
+**現状**: `umbral-pre` のコンパイルを通すためのスタブ。本番ではメッセージ ID やブロックハッシュからエントロピーを注入する必要がある。
+
+---
+
+## 処理の全体フロー（メッセージ 1 件の一生）
+
+```
+HyperBEAM
+  │
+  ├─ 前回のメモリスナップショットをリストア
+  │
+  ├─ alloc(len) → ptr を取得
+  ├─ ptr に JSON を書き込み
+  ├─ handle(ptr, len) を呼ぶ
+  │     │
+  │     ├─ JSON パース → AOMessage
+  │     ├─ dispatch(state, msg)
+  │     │     ├─ ロール確認
+  │     │     ├─ 認可チェック (from == owner_id)
+  │     │     ├─ ハンドラー実行 (state を &mut で変更)
+  │     │     └─ AOResponse を返す
+  │     │
+  │     ├─ AOResponse を JSON シリアライズ
+  │     └─ RESPONSE_BUF に書いて ptr を返す
+  │
+  ├─ response_len() でサイズ取得
+  ├─ レスポンス読み取り
+  ├─ dealloc で解放
+  │
+  └─ 現在のメモリ全体をスナップショット保存
+      → state の変更が永続化される
+```
+
+---
+
+## ステート管理で開発者が意識すべきこと
+
+### メモリ上のすべてが永続化される
+
+KV ストアなら「保存しなければ消える」が、HyperBEAM では **メモリに存在する = 次のメッセージでも存在する**。不要なデータを `static` に蓄積するとスナップショットサイズが増え続ける。
+
+**対策**: 不要になったエントリは明示的に `remove` する。
+
+### メモリは増えるが縮まない
+
+WASM のリニアメモリは `memory.grow` で拡張されるが、**縮小する手段がない**。大量データの insert/remove を繰り返すとメモリフットプリントが肥大化する。
+
+**対策**: 大量データの一時保存を避ける設計にする。完了した capsule データのクリーンアップ戦略を検討する。
+
+### 秘密鍵素材は明示的にゼロ化が必要
+
+メモリが永続化されるため、スコープを抜けてもヒープ上にゴーストデータが残る可能性がある。
+
+**対策**: 秘密素材を扱う型には必ず `Zeroize` + `ZeroizeOnDrop` を derive する（現在の実装は対応済み）。
+
+### メッセージ処理は原子的だが、エラー時もステートは保存される
+
+HyperBEAM はハンドラーが正常に return した時点の状態をスナップショットする。パニックした場合は前回のスナップショットに戻る。しかし **エラーを return しても状態変更は保存される**。
+
+**対策**: エラー時にロールバックが必要なら、明示的に元に戻すコードを書く。
+
+### コントラクトのアップグレードが困難
+
+メモリスナップショットはバイナリレベルでの互換性が必要。構造体のレイアウトが変わると旧スナップショットから復元した状態が壊れる可能性がある。
+
+**対策**: `HashMap<String, Vec<u8>>` のように動的なスキーマを使う（現在の設計はこれに近い）。
+
+### まとめ表
+
+| 観点 | KV ストア脳 | メモリスナップショット脳 |
+|------|-------------|------------------------|
+| 保存 | 明示的に write | **何もしなくても保存される** |
+| 削除 | key を delete | `remove` してもメモリは縮まない |
+| 一時データ | 保存しなければ消える | **static に置くと永続化される** |
+| エラー時 | transaction rollback | **明示的にロールバックが必要** |
+| 大量データ | 必要な分だけ load | 常に全量がメモリ上 |
+| 秘密鍵 | key 削除で消える | **Zeroize 必須** |


### PR DESCRIPTION
## 概要

HyperBEAM-native AO コントラクト設計への移行と、MockAOClient への実 Umbral 再暗号化実装、Phase 1→2→3 の E2E 統合テスト追加を行った PR。旧 `ao/` ディレクトリを `ao_cwao/` にリネームし、新しい HyperBEAM-native コントラクト (`ao/contracts/`) を構築。クライアント側では `external/ao` モジュールを HyperBEAM メッセージ形式に対応させ、E2E テストで PRD 全フローの再現性を検証した。

関連 Issue: #84 (RandAO Holder 選出), #85 (Requester-Process cFrag 収集仲介)

```mermaid
sequenceDiagram
    participant Client as Client (Phase 1)
    participant AO as MockAOClient / AO Contract
    participant Arweave as Arweave (in-memory)
    participant Recovery as Client (Phase 3)

    Client->>Client: Shamir Split (k=3, n=5)
    Client->>Client: AES-GCM Encrypt shares
    Client->>Client: PRE Capsule 生成
    Client->>Client: kFrag 生成 (n=5)
    Client->>AO: DelegateKFrag × 5
    Client->>Arweave: Store CapsulePayload
    Client->>Arweave: Store Encrypted Shares × 5
    Client->>AO: DelegateCapsule × 5
    AO->>AO: perform_reencryption() × 5 (実 Umbral)
    AO-->>AO: cFrag × 5 保存

    Recovery->>Arweave: Retrieve CapsulePayload
    Recovery->>AO: GetCFrag × 5 (k=3 個で十分)
    Recovery->>Recovery: PRE Decrypt → kₒ 復元
    Recovery->>Arweave: Retrieve Encrypted Shares
    Recovery->>Recovery: AES-GCM Decrypt
    Recovery->>Recovery: Shamir Reconstruct → 秘密復元
```

## 変更内容

### ao/ (HyperBEAM-native コントラクト — 新規)
| ファイル | 変更 | 説明 |
|---------|------|------|
| `ao/contracts/src/lib.rs` | 新規 | WASM エントリポイント (`handle`) + グローバル状態管理 |
| `ao/contracts/src/handlers.rs` | 新規 | Init / DelegateKFrag / SubmitCapsule / Reencrypt / GetCFrag ハンドラー + 実 Umbral 再暗号化 |
| `ao/contracts/src/state.rs` | 新規 | `UnsafeCell` ベースのグローバル状態 (WASM メモリスナップショット前提) |
| `ao/contracts/src/types.rs` | 新規 | StoredKeyFrag / StoredCFrag / VerificationData 型定義 |
| `ao/contracts/Cargo.toml` | 新規 | wasm32-unknown-unknown ターゲット、umbral-pre 依存 |

### ao_cwao/ (旧 ao/ リネーム)
| ファイル | 変更 | 説明 |
|---------|------|------|
| `ao_cwao/` | リネーム | 旧 `ao/` → `ao_cwao/` (CosmWasm 互換レイヤー保持) |

### client/src/adapter/external/ao/
| ファイル | 変更 | 説明 |
|---------|------|------|
| `message.rs` | 変更 | HyperBEAM メッセージ形式対応 (DelegateKFrag に holder_process_id 追加、DelegateCapsule に holder ルーティング) |
| `client.rs` | 変更 | AOClient trait — HyperBEAM API 対応 |
| `mod.rs` | 変更 | re-export を HyperBEAM 型に更新 |

### client/src/adapter/external/mock_ao/
| ファイル | 変更 | 説明 |
|---------|------|------|
| `client.rs` | 変更 | `perform_reencryption()` 追加 — 実 Umbral 再暗号化。ダミー cFrag を完全廃止。Capsule デシリアライズを bincode に統一 |

### client/src/usecase/
| ファイル | 変更 | 説明 |
|---------|------|------|
| `core/contract_storage.rs` | 変更 | `new_single_process()` 追加、`send_kfrags` に holder_process_id 伝播、kfrag_id 形式統一 (`{secret_id}_{index}`) |
| `workflow/secret_sharing_service.rs` | 変更 | DelegateCapsule リトライ + kfrag_id 形式修正 |

### client/tests/
| ファイル | 変更 | 説明 |
|---------|------|------|
| `integration/workflow_roundtrip_test.rs` | 変更 | E2E テスト 4 件追加 (Phase 1→2→3 happy path + エラー 3 件) |
| `unit/adapter/external/mock_ao/client.rs` | 変更 | Capsule シリアライズを bincode に統一 |
| `unit/adapter/external/ao/message.rs` | 変更 | holder_process_id 検証テスト追加 |

### docs/
| ファイル | 変更 | 説明 |
|---------|------|------|
| `PRD.md` | 変更 | Phase 2 ステップを HyperBEAM 設計に更新 (Arweave → WASM スナップショット, fetch → push) |
| `contracts/hyperbeam_contract_guide.md` | 新規 | HyperBEAM コントラクト開発ガイド |

## 設計判断

| 項目 | 決定 | 理由 |
|------|------|------|
| AO ランタイム | HyperBEAM-native (`~wasm64@1.0`) | WASM メモリスナップショットで状態が自動永続化 — 明示的 Arweave 保存不要 |
| 状態管理 | `static` + `UnsafeCell` | WASM シングルスレッド保証により安全。CosmWasm の `db_read/db_write` 不要 |
| Capsule シリアライズ | bincode 統一 | Client (`crypto.rs`) が bincode を使用するため、Mock/テストも統一 |
| Mock 再暗号化 | 実 Umbral (ダミー廃止) | E2E テストで PRE の正確性を端から端まで検証するため |
| kFrag/cFrag 構造体 | Mock 内に複製定義 | レイヤー依存を避けつつ、AO コントラクトと同一フォーマットを保持 |
| E2E 閾値パラメータ | k=3, n=5 | 実運用構成で完全な閾値検証 |
| 旧 AO コード | `ao_cwao/` にリネーム保持 | 後方互換性のため削除せず保持 |

## テスト

**全 351 テスト pass** (client: 15 lib + 271 unit + 65 integration)

- `tests/integration/workflow_roundtrip_test.rs` — 4 E2E tests: Phase 1→2→3 happy path (k=3,n=5)、閾値未達エラー、不正 Requester 鍵エラー、Capsule 不存在エラー
- `tests/unit/adapter/external/mock_ao/client.rs` — 12 tests: MockAOClient の DelegateKFrag / DelegateCapsule / Reencrypt / GetCFrag / ListCapsules + エラー注入
- `tests/unit/adapter/external/ao/message.rs` — 12 tests: メッセージ型の構築・シリアライズ・holder_process_id 検証
- `src/usecase/core/contract_storage.rs` — 8 tests: send_kfrags / retrieve_cfrags / delegate_capsule の結合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)