### PR TITLE
feat: [Phase D] E2E integration test — share() + recover() on local HyperBEAM (#90)

### DIFF
--- a/ao/contracts/src/handlers.rs
+++ b/ao/contracts/src/handlers.rs
@@ -3,8 +3,7 @@ use umbral_pre::{self, DefaultDeserialize, DefaultSerialize};
 
 use crate::message::{AOMessage, AOResponse, OutgoingMessage};
 use crate::state::{
-    CapsuleStatus, OwnerCapsuleData, ProcessRole, ProcessState, StoredCFrag, StoredKeyFrag,
-    VerificationData,
+    CapsuleStatus, OwnerCapsuleData, ProcessRole, ProcessState, StoredKeyFrag, VerificationData,
 };
 
 fn parse_byte_array(arr: &[serde_json::Value]) -> Result<Vec<u8>, &'static str> {
@@ -49,6 +48,7 @@ pub fn dispatch(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
 
         // Queries — allowed for any initialized role
         (_, "GetCFrag") => handle_get_cfrag(state, msg),
+        (_, "GetCFrags") => handle_get_cfrags(state, msg),
         (_, "ListCapsules") => handle_list_capsules(state, msg),
 
         (role, action) => {
@@ -126,6 +126,26 @@ fn handle_delegate_kfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse
         .kfrag_holders
         .insert(kfrag_id.clone(), holder_process_id.clone());
 
+    // Single-process (Combined) mode: this process is its own holder, and
+    // HyperBEAM does not push process outboxes in this flow — deliver the
+    // SubmitKFrag inline instead of emitting an outgoing message.
+    if matches!(state.role, Some(ProcessRole::Combined)) {
+        let submit = AOMessage {
+            action: "SubmitKFrag".to_string(),
+            from: msg.from.clone(),
+            id: None,
+            data: Some(json!({
+                "kfrag_id": kfrag_id,
+                "kfrag": kfrag_bytes,
+            })),
+        };
+        let sub_resp = handle_submit_kfrag(state, submit);
+        if !sub_resp.ok {
+            return sub_resp;
+        }
+        return AOResponse::success(json!({ "kfrag_id": kfrag_id, "delegated": true }));
+    }
+
     let outgoing = OutgoingMessage {
         target: holder_process_id,
         action: "SubmitKFrag".to_string(),
@@ -189,6 +209,26 @@ fn handle_delegate_capsule(state: &mut ProcessState, msg: AOMessage) -> AORespon
         .entry(kfrag_id.clone())
         .or_default()
         .push(capsule_id.clone());
+
+    // Same single-process inline delivery as DelegateKFrag — SubmitCapsule
+    // performs the re-encryption that produces the cFrag.
+    if matches!(state.role, Some(ProcessRole::Combined)) {
+        let submit = AOMessage {
+            action: "SubmitCapsule".to_string(),
+            from: msg.from.clone(),
+            id: None,
+            data: Some(json!({
+                "kfrag_id": kfrag_id,
+                "capsule_id": capsule_id,
+                "capsule": capsule_bytes,
+            })),
+        };
+        let sub_resp = handle_submit_capsule(state, submit);
+        if !sub_resp.ok {
+            return sub_resp;
+        }
+        return AOResponse::success(json!({ "capsule_id": capsule_id, "delegated": true }));
+    }
 
     let outgoing = OutgoingMessage {
         target: holder,
@@ -380,6 +420,37 @@ fn handle_get_cfrag(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
     }
 }
 
+// HyperBEAM's wasm-64 snapshot restore is broken across HTTP requests, so the
+// client computes exactly one slot per recovery. This batch query returns every
+// cFrag for a capsule in a single response to make that possible.
+fn handle_get_cfrags(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
+    let data = match msg.data {
+        Some(d) => d,
+        None => return AOResponse::error("Missing data"),
+    };
+    let capsule_id = match data["capsule_id"].as_str() {
+        Some(s) => s.to_string(),
+        None => return AOResponse::error("Missing capsule_id"),
+    };
+
+    let suffix = format!("/{capsule_id}");
+    let cfrags: Vec<serde_json::Value> = state
+        .holder_cfrags
+        .iter()
+        .filter_map(|(cap_key, cfrag_bytes)| {
+            let encoded = cap_key.strip_suffix(&suffix)?;
+            // cap_key = "{len}:{kfrag_id}/{capsule_id}"
+            let kfrag_id = encoded.split_once(':').map(|(_, id)| id)?;
+            Some(json!({ "kfrag_id": kfrag_id, "cfrag": cfrag_bytes }))
+        })
+        .collect();
+
+    AOResponse::success(json!({
+        "capsule_id": capsule_id,
+        "cfrags": cfrags,
+    }))
+}
+
 // ─── ListCapsules ─────────────────────────────────────────────────────────────
 fn handle_list_capsules(state: &mut ProcessState, msg: AOMessage) -> AOResponse {
     let data = match msg.data {
@@ -457,8 +528,8 @@ fn perform_reencryption(
         .to_bytes()
         .map_err(|_| "Failed to serialize cFrag".to_string())?;
 
-    let stored_cfrag = StoredCFrag {
-        fragment_data: cfrag_bytes.to_vec(),
-    };
-    bincode::serialize(&stored_cfrag).map_err(|e| format!("CFrag serialize failed: {e}"))
+    // Store the raw rmp_serde cfrag bytes — the client recovers with
+    // CapsuleFrag::from_bytes directly (see serialization conventions);
+    // a bincode wrapper here would break deserialization on recovery.
+    Ok(cfrag_bytes.to_vec())
 }

--- a/ao/contracts/src/message.rs
+++ b/ao/contracts/src/message.rs
@@ -102,14 +102,14 @@ impl AOIncomingMessage {
 }
 
 /// AOS-compatible response wrapper for JSON-Iface.
-/// JSON-Iface's `json_to_message` expects this format.
+/// JSON-Iface's `results/3` only accepts `{"ok": true, "response": ...}` —
+/// anything else aborts the whole compute replay with a try_clause error.
+/// Contract-level failures therefore must also use `ok: true`, signalled via
+/// the `{"Error": ...}` response shape that `normalize_results/1` understands.
 #[derive(Debug, Serialize)]
 pub struct AOSResponse {
     pub ok: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response: Option<AOSResultBody>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub response: serde_json::Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -176,9 +176,10 @@ impl AOResponse {
     pub fn into_aos_response(self) -> AOSResponse {
         if !self.ok {
             return AOSResponse {
-                ok: false,
-                response: None,
-                error: self.error,
+                ok: true,
+                response: serde_json::json!({
+                    "Error": self.error.unwrap_or_else(|| "Unknown error".to_string()),
+                }),
             };
         }
 
@@ -199,14 +200,15 @@ impl AOResponse {
             .data
             .unwrap_or(serde_json::Value::String(String::new()));
 
+        let body = AOSResultBody {
+            output: AOSOutput { data },
+            messages,
+            spawns: Vec::new(),
+        };
         AOSResponse {
             ok: true,
-            response: Some(AOSResultBody {
-                output: AOSOutput { data },
-                messages,
-                spawns: Vec::new(),
-            }),
-            error: None,
+            response: serde_json::to_value(body)
+                .unwrap_or_else(|_| serde_json::json!({"Error": "serialization failure"})),
         }
     }
 }
@@ -341,9 +343,10 @@ mod tests {
         let json_str = serde_json::to_string(&aos).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
-        assert_eq!(parsed["ok"], false);
-        assert_eq!(parsed["error"], "something failed");
-        assert!(parsed.get("response").is_none());
+        // JSON-Iface aborts on ok=false, so errors stay ok=true with the
+        // `{"Error": ...}` shape understood by normalize_results.
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["response"]["Error"], "something failed");
     }
 
     #[test]

--- a/ao/contracts/src/state.rs
+++ b/ao/contracts/src/state.rs
@@ -82,11 +82,6 @@ pub struct StoredKeyFrag {
     pub precursor: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
-pub struct StoredCFrag {
-    pub fragment_data: Vec<u8>,
-}
-
 /// Deserialized from StoredKeyFrag.verification_data for kFrag verification.
 #[derive(Serialize, Deserialize)]
 pub struct VerificationData {

--- a/ao/scripts/cache-wasm.escript
+++ b/ao/scripts/cache-wasm.escript
@@ -1,0 +1,38 @@
+#!/usr/bin/env escript
+%%! -sname formix_cache_client -setcookie hyperbeam_sandbox
+
+%% cache-wasm.escript — Cache a WASM image on a running local HyperBEAM node.
+%%
+%% ~cache@1.0/write over HTTP only stores raw binaries (at `data/<hash>`),
+%% which dev_wasm:init cannot resolve as an image. dev_wasm:cache_wasm_image
+%% writes a proper message (`#{body => Bin}`) whose ID works as a process
+%% `image` reference, so we call it over Erlang RPC instead.
+%%
+%% Usage: HB_NODE_SNAME=hb_sandbox escript cache-wasm.escript <abs-path-to-wasm>
+%% Prints the 43-char image ID on stdout.
+
+main([WasmPath]) ->
+    Sname = os:getenv("HB_NODE_SNAME", "hb_sandbox"),
+    {ok, Hostname} = inet:gethostname(),
+    NodeName = list_to_atom(Sname ++ "@" ++ Hostname),
+    case net_adm:ping(NodeName) of
+        pong ->
+            Result = rpc:call(NodeName, dev_wasm, cache_wasm_image,
+                              [list_to_binary(WasmPath)]),
+            case Result of
+                #{<<"image">> := ImageID} ->
+                    io:format("~s~n", [ImageID]);
+                Other ->
+                    io:format(standard_error, "Unexpected result: ~p~n", [Other]),
+                    halt(1)
+            end;
+        pang ->
+            io:format(standard_error,
+                      "Cannot connect to ~s (is the HyperBEAM node running?)~n",
+                      [NodeName]),
+            halt(1)
+    end;
+main(_) ->
+    io:format(standard_error,
+              "Usage: escript cache-wasm.escript <abs-path-to-wasm>~n", []),
+    halt(1).

--- a/ao/scripts/deploy-hyperbeam.sh
+++ b/ao/scripts/deploy-hyperbeam.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# HyperBEAM E2E test runner
+# Prerequisites: running HyperBEAM node, WALLET_PATH, WASM target installed
+#
+# Usage: WALLET_PATH=/path/to/wallet.json ./ao/scripts/deploy-hyperbeam.sh
+
+HB_PORT="${HB_PORT:-10000}"
+HB_URL="http://localhost:${HB_PORT}"
+
+echo "=== HyperBEAM E2E Test Runner ==="
+
+# 1. Check wallet
+if [ -z "${WALLET_PATH:-}" ]; then
+    echo "ERROR: WALLET_PATH is not set"
+    echo "  export WALLET_PATH=/path/to/arweave-wallet.json"
+    exit 1
+fi
+if [ ! -f "$WALLET_PATH" ]; then
+    echo "ERROR: wallet file not found: $WALLET_PATH"
+    exit 1
+fi
+echo "[OK] Wallet: $WALLET_PATH"
+
+# 2. Check HyperBEAM health
+if ! curl -sf "${HB_URL}/~meta@1.0/info" > /dev/null 2>&1; then
+    echo "ERROR: HyperBEAM not reachable at ${HB_URL}"
+    echo "  Start it with: cd hyperbeam-sandbox && ./scripts/start.sh"
+    exit 1
+fi
+echo "[OK] HyperBEAM: ${HB_URL}"
+
+# Repo has no root cargo workspace — client/ and ao/contracts/ are standalone crates,
+# so each cargo invocation needs an explicit manifest path.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# 3. Build WASM
+if ! command -v wasm-tools >/dev/null 2>&1; then
+    echo "ERROR: wasm-tools is required (cargo install wasm-tools)"
+    exit 1
+fi
+echo "Building WASM contract..."
+# -reference-types prevents reftype constructs in our own code; the prebuilt
+# core/std still carry call_indirect overlong LEB encodings, which HyperBEAM's
+# WAMR (built without REF_TYPES) rejects with "zero byte expected" — see #101.
+RUSTFLAGS="-C target-feature=-reference-types" \
+    cargo build --manifest-path "${REPO_ROOT}/ao/contracts/Cargo.toml" \
+    --target wasm32-unknown-unknown --release
+RAW_WASM="${REPO_ROOT}/ao/contracts/target/wasm32-unknown-unknown/release/formix_contract.wasm"
+if [ ! -f "$RAW_WASM" ]; then
+    echo "ERROR: WASM binary not found at $RAW_WASM"
+    exit 1
+fi
+
+# wasm-tools print|parse round-trip re-encodes the binary canonically,
+# rewriting the overlong LEBs into the MVP form WAMR accepts (#101).
+WASM_PATH="${RAW_WASM%.wasm}.canonical.wasm"
+WAT_TMP="$(mktemp -t formix-contract).wat"
+wasm-tools print "$RAW_WASM" -o "$WAT_TMP"
+wasm-tools parse "$WAT_TMP" -o "$WASM_PATH"
+rm -f "$WAT_TMP"
+echo "[OK] WASM: $WASM_PATH ($(wc -c < "$WASM_PATH") bytes)"
+
+# 4. Cache the image on the node (RPC — see cache-wasm.escript for why
+#    the HTTP cache device cannot be used for images)
+echo "Caching WASM image on the node..."
+WASM_IMAGE_ID="$(escript "${REPO_ROOT}/ao/scripts/cache-wasm.escript" "$WASM_PATH")"
+if [ -z "$WASM_IMAGE_ID" ]; then
+    echo "ERROR: failed to obtain image ID from cache-wasm.escript"
+    exit 1
+fi
+echo "[OK] Image ID: $WASM_IMAGE_ID"
+
+# 5. Run E2E test
+echo "Running E2E test..."
+export WASM_IMAGE_ID
+cargo test --manifest-path "${REPO_ROOT}/client/Cargo.toml" \
+    --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture
+echo "=== DONE ==="

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -626,6 +626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +667,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "umbral-pre",
+ "uuid",
  "wiremock",
  "zeroize",
 ]
@@ -825,9 +832,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -881,9 +901,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1171,6 +1206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1240,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1288,6 +1331,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1500,6 +1549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1659,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1946,6 +2011,12 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2409,6 +2480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2519,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2482,7 +2570,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2542,6 +2639,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2762,6 +2893,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -47,3 +47,4 @@ cw-multi-test = "0.13.4"
 tokio = { version = "1", features = ["rt", "macros"] }
 wiremock = "0.5"
 dotenvy = "0.15"
+uuid = { version = "1", features = ["v4"] }

--- a/client/src/adapter/external/ao/hyperbeam_client.rs
+++ b/client/src/adapter/external/ao/hyperbeam_client.rs
@@ -40,12 +40,12 @@ impl HyperBEAMClient {
     async fn schedule(
         &self,
         process_id: &str,
-        msg: &AOExecuteMsg,
+        action: &str,
+        payload_data: &serde_json::Value,
     ) -> Result<(u16, String, Vec<(String, String)>), AOCommunicationError> {
         let url = format!("{}/{}/schedule", self.base_url(), process_id);
 
-        let action = msg.action();
-        let payload = serde_json::to_string(msg.data()).map_err(|e| {
+        let payload = serde_json::to_string(payload_data).map_err(|e| {
             AOCommunicationError::serialization_error(format!("serialize msg data: {e}"))
         })?;
         let body = payload.as_bytes();
@@ -90,12 +90,19 @@ impl HyperBEAMClient {
         Ok((status, body_text, headers))
     }
 
-    async fn compute(
+    // Drills into a sub-field of the computed slot (e.g. "results/data") and
+    // asks for the JSON codec so the response is plain JSON instead of TABM.
+    async fn compute_subpath(
         &self,
         process_id: &str,
         slot: u64,
+        subpath: &str,
     ) -> Result<(u16, String, Vec<(String, String)>), AOCommunicationError> {
-        let url = format!("{}/{}/compute", self.base_url(), process_id);
+        let url = if subpath.is_empty() {
+            format!("{}/{}/compute", self.base_url(), process_id)
+        } else {
+            format!("{}/{}/compute/{}", self.base_url(), process_id, subpath)
+        };
         let resp = self
             .http
             .get(&url)
@@ -117,31 +124,6 @@ impl HyperBEAMClient {
         Ok((status, body, headers))
     }
 
-    async fn now(
-        &self,
-        process_id: &str,
-    ) -> Result<(u16, String, Vec<(String, String)>), AOCommunicationError> {
-        let url = format!("{}/{}/now", self.base_url(), process_id);
-        let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| AOCommunicationError::connection_error(format!("now GET: {e}")))?;
-
-        let status = resp.status().as_u16();
-        let headers: Vec<(String, String)> = resp
-            .headers()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-            .collect();
-        let body = Box::pin(resp.text())
-            .await
-            .map_err(|e| AOCommunicationError::connection_error(format!("read now body: {e}")))?;
-
-        Ok((status, body, headers))
-    }
-
     fn extract_slot(headers: &[(String, String)], body: &str) -> Option<u64> {
         for (key, val) in headers {
             if key.to_lowercase() == "slot" {
@@ -155,42 +137,18 @@ impl HyperBEAMClient {
         }
         None
     }
-
-    fn parse_response(status: u16, body: &str, _headers: &[(String, String)]) -> AONativeResponse {
-        if status >= 400 {
-            return AONativeResponse::error_response(format!(
-                "HTTP {status}: {}",
-                &body[..body.len().min(200)]
-            ));
-        }
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
-            let ok = v.get("ok").and_then(|o| o.as_bool()).unwrap_or(true);
-            let error = v
-                .get("error")
-                .and_then(|e| e.as_str())
-                .map(|s| s.to_string());
-            if let Some(err) = error {
-                return AONativeResponse::error_response(err);
-            }
-            if !ok {
-                return AONativeResponse::error_response("Process returned ok=false");
-            }
-            AONativeResponse::success(v)
-        } else {
-            AONativeResponse::success(serde_json::Value::String(body.to_string()))
-        }
-    }
 }
 
-#[async_trait]
-impl AOClient for HyperBEAMClient {
-    async fn execute(
+impl HyperBEAMClient {
+    async fn schedule_and_compute(
         &self,
         process_id: &str,
-        msg: AOExecuteMsg,
-    ) -> Result<AONativeResponse, AOCommunicationError> {
+        action: &str,
+        payload_data: &serde_json::Value,
+        subpath: &str,
+    ) -> Result<(u16, String, Vec<(String, String)>), AOCommunicationError> {
         let (sched_status, sched_body, sched_headers) =
-            Box::pin(self.schedule(process_id, &msg)).await?;
+            Box::pin(self.schedule(process_id, action, payload_data)).await?;
 
         if sched_status >= 400 {
             return Err(AOCommunicationError::execution_error(
@@ -205,23 +163,57 @@ impl AOClient for HyperBEAMClient {
 
         let slot = Self::extract_slot(&sched_headers, &sched_body).unwrap_or(1);
 
-        let (comp_status, comp_body, comp_headers) =
-            Box::pin(self.compute(process_id, slot)).await?;
-
-        Ok(Self::parse_response(comp_status, &comp_body, &comp_headers))
+        Box::pin(self.compute_subpath(process_id, slot, subpath)).await
     }
+}
 
-    async fn query(
+#[async_trait]
+impl AOClient for HyperBEAMClient {
+    // Schedule-only: computing intermediate slots leaves broken wasm-64
+    // snapshots on the node (cross-request restore loses all state), so the
+    // process is computed exactly once — when query() reads the results.
+    async fn execute(
         &self,
         process_id: &str,
-        _msg: AOQueryMsg,
-    ) -> Result<Binary, AOCommunicationError> {
-        let (status, body, _headers) = Box::pin(self.now(process_id)).await?;
+        msg: AOExecuteMsg,
+    ) -> Result<AONativeResponse, AOCommunicationError> {
+        let (status, body, _headers) =
+            Box::pin(self.schedule(process_id, msg.action(), msg.data())).await?;
+
         if status >= 400 {
             return Err(AOCommunicationError::execution_error(
                 process_id,
                 format!(
-                    "now query failed (HTTP {}): {}",
+                    "schedule failed (HTTP {}): {}",
+                    status,
+                    &body[..body.len().min(200)]
+                ),
+            ));
+        }
+        Ok(AONativeResponse::success(serde_json::Value::Null))
+    }
+
+    // Read-only queries are still AO messages on HyperBEAM: schedule the
+    // query action and read the contract's JSON response from compute.
+    async fn query(
+        &self,
+        process_id: &str,
+        msg: AOQueryMsg,
+    ) -> Result<Binary, AOCommunicationError> {
+        let (status, body, _headers) = Box::pin(self.schedule_and_compute(
+            process_id,
+            msg.action(),
+            msg.data(),
+            // JSON-Iface stores the contract's response payload at results/data;
+            // the trailing device call renders it as a plain JSON body.
+            "results/data/serialize~json@1.0",
+        ))
+        .await?;
+        if status >= 400 {
+            return Err(AOCommunicationError::execution_error(
+                process_id,
+                format!(
+                    "query compute failed (HTTP {}): {}",
                     status,
                     &body[..body.len().min(200)]
                 ),

--- a/client/src/adapter/external/ao/message.rs
+++ b/client/src/adapter/external/ao/message.rs
@@ -181,6 +181,20 @@ impl AOQueryMsg {
         }
     }
 
+    /// Get all cFrags for a Capsule in one response.
+    ///
+    /// Single-compute recovery path: HyperBEAM cannot restore wasm-64
+    /// snapshots across requests, so recovery must read everything from one
+    /// computed slot.
+    pub fn get_cfrags(capsule_id: impl Into<String>) -> Self {
+        Self {
+            action: "GetCFrags".to_string(),
+            data: serde_json::json!({
+                "capsule_id": capsule_id.into(),
+            }),
+        }
+    }
+
     /// List Capsules associated with a kFrag (with optional pagination).
     ///
     /// Action name: `"ListCapsules"` — must match the contract handler.
@@ -245,6 +259,19 @@ impl AONativeResponse {
 }
 
 // ─── Response sub-types (for GetCFrag deserialization) ───────────────────────
+
+/// Parsed response for a GetCFrags batch query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetCFragsResponse {
+    pub capsule_id: String,
+    pub cfrags: Vec<CFragEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CFragEntry {
+    pub kfrag_id: String,
+    pub cfrag: Vec<u8>,
+}
 
 /// Parsed response for a GetCFrag query.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/client/src/adapter/external/ao/mod.rs
+++ b/client/src/adapter/external/ao/mod.rs
@@ -28,6 +28,6 @@ pub use config::AOConfig;
 #[cfg(feature = "hyperbeam")]
 pub use hyperbeam_client::HyperBEAMClient;
 pub use message::{
-    validate_binary, validate_id, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary,
-    GetCFragResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH,
+    validate_binary, validate_id, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, CFragEntry,
+    GetCFragResponse, GetCFragsResponse, MAX_BINARY_SIZE, MAX_ID_LENGTH,
 };

--- a/client/src/adapter/external/mock_ao/client.rs
+++ b/client/src/adapter/external/mock_ao/client.rs
@@ -18,7 +18,8 @@ use umbral_pre::{DefaultDeserialize, DefaultSerialize};
 
 use crate::adapter::errors::AOCommunicationError;
 use crate::adapter::external::ao::{
-    AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, GetCFragResponse,
+    AOClient, AOExecuteMsg, AONativeResponse, AOQueryMsg, Binary, CFragEntry, GetCFragResponse,
+    GetCFragsResponse,
 };
 
 // ─── Local structs mirroring contract's StoredKeyFrag / VerificationData ──────
@@ -496,6 +497,37 @@ impl AOClient for MockAOClient {
                     kfrag_id: kfrag_id.to_string(),
                     capsule_id: capsule_id.to_string(),
                     cfrag: cfrag_data,
+                };
+                let json = serde_json::to_vec(&response).map_err(|e| {
+                    AOCommunicationError::SerializationError {
+                        details: e.to_string(),
+                    }
+                })?;
+                Ok(Binary::from(json))
+            }
+            "GetCFrags" => {
+                let capsule_id = data_str(d, "capsule_id")?;
+                let s = self.cfrag_storage.read().unwrap();
+                // mock key format: "{kfrag_id}:{capsule_id}"
+                let suffix = format!(":{capsule_id}");
+                let mut cfrags: Vec<CFragEntry> = s
+                    .get(process_id)
+                    .map(|m| {
+                        m.iter()
+                            .filter_map(|(key, bytes)| {
+                                let kfrag_id = key.strip_suffix(&suffix)?;
+                                Some(CFragEntry {
+                                    kfrag_id: kfrag_id.to_string(),
+                                    cfrag: bytes.clone(),
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                cfrags.sort_by(|a, b| a.kfrag_id.cmp(&b.kfrag_id));
+                let response = GetCFragsResponse {
+                    capsule_id: capsule_id.to_string(),
+                    cfrags,
                 };
                 let json = serde_json::to_vec(&response).map_err(|e| {
                     AOCommunicationError::SerializationError {

--- a/client/src/usecase/core/contract_storage.rs
+++ b/client/src/usecase/core/contract_storage.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AOQueryMsg, GetCFragResponse};
+use crate::adapter::external::ao::{AOClient, AOExecuteMsg, AOQueryMsg, GetCFragsResponse};
 use crate::service::error::{ServiceError, ServiceResult};
 use crate::usecase::core::crypto::{CFragData, KeyFragment};
 
@@ -178,37 +178,38 @@ impl<A: AOClient> ContractStorage for ContractStorageImpl<A> {
         capsule_id: &str,
         process_id: &str,
     ) -> ServiceResult<Vec<CFragData>> {
-        let mut cfrags = Vec::new();
+        // Single batch query: HyperBEAM cannot restore wasm-64 snapshots
+        // across requests, so recovery reads all cFrags from one computed slot.
+        let msg = AOQueryMsg::get_cfrags(capsule_id);
+        let result = self
+            .ao_client
+            .query(process_id, msg)
+            .await
+            .map_err(|e| ServiceError::ao_network_error(format!("GetCFrags query: {e}")))?;
 
-        for i in 0..total_shares {
-            let kfrag_id = format!("{secret_id}_{i}");
-            let msg = AOQueryMsg::get_cfrag(&kfrag_id, capsule_id);
-
-            match self.ao_client.query(process_id, msg).await {
-                Ok(result) => {
-                    let response: GetCFragResponse = serde_json::from_slice(result.as_slice())
-                        .map_err(|e| {
-                            ServiceError::ao_network_error(format!(
-                                "Failed to parse cFrag for {kfrag_id}: {e}"
-                            ))
-                        })?;
-                    cfrags.push(CFragData {
-                        cfrag_data: response.cfrag,
-                        holder_id: process_id.to_string(),
-                    });
-                }
-                Err(e) => {
-                    let msg = e.to_string();
-                    // "not ready" means cFrag hasn't been generated yet — expected, skip
-                    if msg.contains("not ready") || msg.contains("CFrag not ready") {
-                        continue;
-                    }
-                    return Err(ServiceError::ao_network_error(format!(
-                        "Failed to query cFrag for {kfrag_id}: {msg}"
-                    )));
-                }
-            }
+        let value: serde_json::Value = serde_json::from_slice(result.as_slice())
+            .map_err(|e| ServiceError::ao_network_error(format!("Failed to parse cFrags: {e}")))?;
+        // Contract-level errors arrive as a bare string
+        // (`{"Error": ...}` response shape → results/data).
+        if let Some(err) = value.as_str() {
+            return Err(ServiceError::ao_network_error(format!(
+                "GetCFrags failed: {err}"
+            )));
         }
+        let response: GetCFragsResponse = serde_json::from_value(value)
+            .map_err(|e| ServiceError::ao_network_error(format!("Failed to parse cFrags: {e}")))?;
+
+        let prefix = format!("{secret_id}_");
+        let mut cfrags: Vec<CFragData> = response
+            .cfrags
+            .into_iter()
+            .filter(|entry| entry.kfrag_id.starts_with(&prefix))
+            .map(|entry| CFragData {
+                cfrag_data: entry.cfrag,
+                holder_id: process_id.to_string(),
+            })
+            .collect();
+        cfrags.truncate(total_shares as usize);
 
         Ok(cfrags)
     }

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -22,4 +22,7 @@ mod integration {
     mod secret_recovery_workflow_test;
     mod secret_sharing_workflow_test;
     mod workflow_roundtrip_test;
+
+    #[cfg(feature = "hyperbeam")]
+    mod test_hyperbeam_e2e;
 }

--- a/client/tests/integration/test_hyperbeam_e2e.rs
+++ b/client/tests/integration/test_hyperbeam_e2e.rs
@@ -1,0 +1,305 @@
+//! HyperBEAM E2E Integration Test
+//!
+//! Verifies the complete share() + recover() flow against a real HyperBEAM node.
+//! Requires: running HyperBEAM instance, wallet file, compiled WASM binary.
+//!
+//! Run: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture`
+#![allow(clippy::large_futures)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use zeroize::Zeroizing;
+
+use formix::adapter::external::ao::signer;
+use formix::adapter::external::ao::wallet::ArweaveJWK;
+use formix::adapter::external::ao::{AOClient, AOConfig, AOExecuteMsg, HyperBEAMClient};
+use formix::usecase::core::contract_storage::ContractStorageImpl;
+use formix::usecase::core::crypto::{CryptoService, CryptoServiceImpl as CoreCryptoServiceImpl};
+use formix::usecase::core::storage::ArweaveStorageServiceImpl;
+use formix::usecase::service::{
+    CryptoServiceImpl as ServiceCryptoServiceImpl, StorageServiceImpl as ServiceStorageServiceImpl,
+};
+use formix::usecase::workflow::{
+    SecretRecoveryWorkflowService, SecretRecoveryWorkflowServiceImpl, SecretSharingWorkflowService,
+    SecretSharingWorkflowServiceImpl,
+};
+use formix::usecase::{SecretRecoveryRequest, SecretSharingRequest};
+
+// ─── Helper functions ────────────────────────────────────────────────────────
+
+fn load_wallet() -> Option<ArweaveJWK> {
+    let Ok(path) = std::env::var("WALLET_PATH") else {
+        eprintln!("WALLET_PATH not set — skipping HyperBEAM E2E test");
+        return None;
+    };
+    match ArweaveJWK::from_file(&path) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            eprintln!("Failed to load wallet from {path}: {e}");
+            None
+        }
+    }
+}
+
+async fn check_hyperbeam_reachable(base_url: &str) -> bool {
+    let url = format!("{base_url}/~meta@1.0/info");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap();
+    client
+        .get(&url)
+        .send()
+        .await
+        .is_ok_and(|resp| resp.status().is_success())
+}
+
+fn wasm_image_id() -> Option<String> {
+    match std::env::var("WASM_IMAGE_ID") {
+        Ok(id) if !id.trim().is_empty() => Some(id.trim().to_string()),
+        _ => {
+            eprintln!(
+                "WASM_IMAGE_ID not set — run via ao/scripts/deploy-hyperbeam.sh, \
+                 which caches the image and sets it"
+            );
+            None
+        }
+    }
+}
+
+async fn spawn_process(
+    http: &reqwest::Client,
+    base_url: &str,
+    image_id: &str,
+    scheduler_location: &str,
+    rsa_key: &rsa::RsaPrivateKey,
+    sig_name: &str,
+) -> Result<String, String> {
+    let url = format!("{base_url}/schedule");
+    let seed = uuid::Uuid::new_v4().to_string();
+
+    // Mirrors dev_process:test_aos_process — the canonical JSON-Iface stack
+    // config. List/integer fields must carry ao-types annotations and
+    // structured-field encoding; sending them as plain strings breaks
+    // dev_stack (case_clause) and Multipass.
+    let headers: BTreeMap<String, String> = BTreeMap::from([
+        (
+            "ao-types".to_string(),
+            "device-stack=\"list\", passes=\"integer\", stack-keys=\"list\"".to_string(),
+        ),
+        ("authority".to_string(), scheduler_location.to_string()),
+        ("device".to_string(), "process@1.0".to_string()),
+        (
+            "device-stack".to_string(),
+            "\"WASI@1.0\", \"JSON-Iface@1.0\", \"WASM-64@1.0\", \"Multipass@1.0\"".to_string(),
+        ),
+        ("execution-device".to_string(), "stack@1.0".to_string()),
+        ("image".to_string(), image_id.to_string()),
+        ("output-prefix".to_string(), "wasm".to_string()),
+        ("passes".to_string(), "2".to_string()),
+        ("patch-from".to_string(), "/results/outbox".to_string()),
+        ("scheduler".to_string(), scheduler_location.to_string()),
+        ("scheduler-device".to_string(), "scheduler@1.0".to_string()),
+        (
+            "scheduler-location".to_string(),
+            scheduler_location.to_string(),
+        ),
+        (
+            "stack-keys".to_string(),
+            "\"init\", \"compute\", \"snapshot\", \"normalize\"".to_string(),
+        ),
+        ("test-random-seed".to_string(), seed),
+        ("type".to_string(), "Process".to_string()),
+    ]);
+
+    let signed = signer::sign_message(rsa_key, &headers, &[], sig_name)
+        .map_err(|e| format!("sign_message failed: {e}"))?;
+
+    let mut req = http.post(&url);
+    for (name, value) in &headers {
+        req = req.header(name.as_str(), value.as_str());
+    }
+    if !signed.content_digest_header.is_empty() {
+        req = req.header("content-digest", &signed.content_digest_header);
+    }
+    let resp = req
+        .header("signature", &signed.signature_header)
+        .header("signature-input", &signed.signature_input_header)
+        .send()
+        .await
+        .map_err(|e| format!("spawn POST failed: {e}"))?;
+
+    let status = resp.status();
+    let resp_headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("read spawn response: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("spawn HTTP {status}: {body}"));
+    }
+
+    // Extract process ID from response headers or body
+    let process_id = resp_headers
+        .iter()
+        .find(|(k, _)| k.to_lowercase() == "process-id" || k.to_lowercase() == "process")
+        .map(|(_, v)| v.clone())
+        .or_else(|| {
+            serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| {
+                    v.get("process")
+                        .or_else(|| v.get("id"))
+                        .or_else(|| v.get("process-id"))
+                        .and_then(|p| p.as_str())
+                        .map(ToString::to_string)
+                })
+        })
+        .unwrap_or_else(|| body.trim().to_string());
+
+    // Verify process exists via GET /{process_id}/compute with slot=0
+    let verify_url = format!("{base_url}/{process_id}/compute");
+    let verify_resp = http
+        .get(&verify_url)
+        .header("slot", "0")
+        .send()
+        .await
+        .map_err(|e| format!("verify process GET failed: {e}"))?;
+
+    if verify_resp.status().as_u16() >= 500 {
+        return Err(format!(
+            "process {process_id} verification failed: HTTP {}",
+            verify_resp.status()
+        ));
+    }
+
+    Ok(process_id)
+}
+
+// ─── Main E2E test ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_hyperbeam_e2e_share_and_recover() {
+    // 1. Load wallet
+    let Some(wallet) = load_wallet() else {
+        return;
+    };
+
+    // 2. Create AOConfig with 60s timeout
+    let base_url =
+        std::env::var("HYPERBEAM_URL").unwrap_or_else(|_| "http://localhost:10000".to_string());
+    let config = AOConfig::new(&base_url, &base_url, &base_url, 60_000)
+        .expect("AOConfig creation should not fail");
+
+    // 3. Check HyperBEAM reachable
+    if !check_hyperbeam_reachable(&base_url).await {
+        eprintln!("HyperBEAM not reachable at {base_url} — skipping E2E test");
+        return;
+    }
+
+    // 4. Image ID of the cached WASM module
+    let Some(image_id) = wasm_image_id() else {
+        return;
+    };
+
+    // 5. Extract signing material from wallet
+    let rsa_key = wallet
+        .to_rsa_private_key()
+        .expect("wallet RSA key extraction failed");
+    let sig_name = wallet.sig_name().expect("wallet sig_name failed");
+    let address = wallet.address().expect("wallet address failed");
+
+    // 6. Create reqwest::Client with 60s timeout
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .expect("HTTP client creation failed");
+
+    // 7. Spawn process referencing the cached image
+    let process_id = spawn_process(&http, &base_url, &image_id, &address, &rsa_key, &sig_name)
+        .await
+        .expect("process spawn failed");
+    eprintln!("Process spawned: {process_id}");
+
+    // 9. Create HyperBEAMClient, send Init("Owner")
+    let hb_client =
+        Arc::new(HyperBEAMClient::new(config, &wallet).expect("HyperBEAMClient creation failed"));
+
+    let init_resp = hb_client
+        .execute(&process_id, AOExecuteMsg::init("Combined"))
+        .await
+        .expect("Init message failed");
+    assert!(init_resp.ok, "Init should succeed: {:?}", init_resp.error);
+    eprintln!("Process initialized as Combined");
+
+    // 10. Wire services (same pattern as workflow_roundtrip_test.rs)
+    let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
+    let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
+    let arweave = Arc::new(ArweaveStorageServiceImpl::default());
+    let contract = Arc::new(ContractStorageImpl::new_single_process(Arc::clone(
+        &hb_client,
+    )));
+    let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
+
+    let sharing_service =
+        SecretSharingWorkflowServiceImpl::new(Arc::clone(&service_crypto), Arc::clone(&storage));
+    let recovery_service = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage);
+
+    // 11. Generate keypairs
+    let (owner_sk, owner_pk) = core_crypto.generate_keypair().unwrap();
+    let (requester_sk, requester_pk) = core_crypto.generate_keypair().unwrap();
+
+    let original_secret = b"HyperBEAM E2E test secret (k=3, n=5)!";
+    let secret_data: Vec<u8> = original_secret.to_vec();
+
+    // 12. Phase 1: execute_secret_sharing
+    eprintln!("Executing Phase 1: secret sharing...");
+    let phase1 = sharing_service
+        .execute_secret_sharing(SecretSharingRequest {
+            secret: Zeroizing::new(secret_data.clone()),
+            owner_secret_key: owner_sk,
+            owner_public_key: owner_pk.clone(),
+            requester_public_key: requester_pk,
+            threshold: 3,
+            total_shares: 5,
+            owner_process_id: process_id.clone(),
+            metadata: None,
+        })
+        .await
+        .expect("Phase 1 secret sharing failed");
+
+    eprintln!(
+        "Phase 1 complete: secret_id={}, kfrag_count={}, share_txs={}",
+        phase1.secret_id,
+        phase1.kfrag_count,
+        phase1.share_tx_ids.len()
+    );
+    assert_eq!(phase1.kfrag_count, 5);
+    assert_eq!(phase1.share_tx_ids.len(), 5);
+
+    // 13. Phase 3: execute_secret_recovery
+    eprintln!("Executing Phase 3: secret recovery...");
+    let phase3 = recovery_service
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: phase1.secret_id,
+            requester_secret_key: requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: process_id,
+        })
+        .await
+        .expect("Phase 3 secret recovery failed");
+
+    // 14. Verify recovered secret matches original
+    assert_eq!(
+        phase3.recovered_secret, secret_data,
+        "Recovered secret must match original"
+    );
+    eprintln!("E2E SUCCESS: recovered secret matches original");
+}

--- a/deploy.example.json
+++ b/deploy.example.json
@@ -5,5 +5,10 @@
     "ao_mu": "https://mu.ao-testnet.xyz",
     "ao_cu": "https://cu.ao-testnet.xyz",
     "arweave": "https://arweave.net"
+  },
+  "hyperbeam": {
+    "url": "http://localhost:10000",
+    "module_id": "YOUR_CACHED_WASM_ID",
+    "process_id": "YOUR_HYPERBEAM_PROCESS_ID"
   }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -168,6 +168,7 @@ status: "active"
 | MockAOClient | ✅ | ✅ | AO client test mock |
 | ArweaveClient Tests | ✅ | ✅ | Arweave transaction signing/verification |
 | E2E arlocal Investigation | 🟡 | 🟡 | Local Arweave testing setup |
+| HyperBEAM E2E (`test_hyperbeam_e2e`) | ✅ | ✅ | share() → recover() against a real local HyperBEAM node; run via `ao/scripts/deploy-hyperbeam.sh` |
 
 ---
 
@@ -210,6 +211,7 @@ status: "active"
 
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
+| 2.3.0 | 2026-06-11 | Local HyperBEAM E2E green: signer keyid fix, WASM canonicalization (wasm-tools), schedule-only execute + single-compute batch GetCFrags recovery, Combined-role inline submit delivery, CI/lint/audit green (#95-#102) | FORMIX Development Team |
 | 2.2.0 | 2026-05-06 | AO Contract ABI migration: JSON-Iface compatible handle(msg_ptr, env_ptr), AO Tags message parsing, AOS response format, removed dead CosmWasm code | FORMIX Development Team |
 | 2.1.0 | 2026-02-23 | Extract all inline tests from client/src/ to client/tests/unit/ (273 unit tests, 0 inline tests remaining) | FORMIX Development Team |
 | 2.0.0 | 2026-02-16 | Major docs cleanup: removed 30 outdated docs files, updated status to reflect actual client/src/ implementation (entities, services, controllers, adapters) | FORMIX Development Team |

--- a/docs/superpowers/plans/2026-05-11-hyperbeam-e2e-integration-test.md
+++ b/docs/superpowers/plans/2026-05-11-hyperbeam-e2e-integration-test.md
@@ -1,0 +1,820 @@
+# HyperBEAM E2E Integration Test Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify the full FORMIX share → recover flow against a real local HyperBEAM node using `HyperBEAMClient`.
+
+**Architecture:** Manual service wiring bypassing the existing DI type aliases to combine in-memory Arweave storage with a real `HyperBEAMClient`. The test file includes helpers for WASM caching and process spawning via HTTP, reusing existing `signer.rs` and `wallet.rs`. A thin shell wrapper validates prerequisites and runs the test.
+
+**Tech Stack:** Rust (tokio async test), HyperBEAMClient, RFC-9421 signing, reqwest HTTP, Umbral TPRE
+
+**Spec:** `docs/superpowers/specs/2026-05-11-hyperbeam-e2e-integration-test-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `client/tests/integration.rs` | Modify (1 line) | Add `#[cfg(feature = "hyperbeam")] mod test_hyperbeam_e2e;` |
+| `client/tests/integration/test_hyperbeam_e2e.rs` | Create (~250 lines) | E2E test: wallet load, WASM cache, process spawn, share, recover |
+| `ao/scripts/deploy-hyperbeam.sh` | Create (~40 lines) | Prereq check + WASM build + test runner |
+| `deploy.example.json` | Modify | Add `hyperbeam` section |
+
+---
+
+## Chunk 1: Module Registration + Test Skeleton
+
+### Task 1: Register the test module conditionally
+
+**Files:**
+- Modify: `client/tests/integration.rs:18-25`
+
+- [ ] **Step 1: Add the feature-gated module to integration.rs**
+
+Add `#[cfg(feature = "hyperbeam")] mod test_hyperbeam_e2e;` inside the existing `mod integration { ... }` block, after the last existing mod:
+
+```rust
+mod integration {
+    #[allow(deprecated)]
+    mod actions_integration_test;
+    mod builder_api_test;
+    mod secret_recovery_workflow_test;
+    mod secret_sharing_workflow_test;
+    mod workflow_roundtrip_test;
+    #[cfg(feature = "hyperbeam")]
+    mod test_hyperbeam_e2e;
+}
+```
+
+- [ ] **Step 2: Verify compilation without the feature (default build)**
+
+Run: `cargo check -p formix --tests 2>&1 | tail -5`
+Expected: SUCCESS (the new module is gated and ignored)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/tests/integration.rs
+git commit -m "test: register hyperbeam E2E module (feature-gated)"
+```
+
+---
+
+### Task 2: Create the test file skeleton with imports
+
+**Files:**
+- Create: `client/tests/integration/test_hyperbeam_e2e.rs`
+
+- [ ] **Step 1: Write the skeleton file with all imports and a placeholder test**
+
+```rust
+//! HyperBEAM E2E Integration Test — share() + recover() on real HyperBEAM
+//!
+//! Requires:
+//! - A running HyperBEAM node at localhost:10000
+//! - WALLET_PATH env var pointing to an Arweave JWK file
+//! - WASM binary built: cargo build -p formix-ao-contract --target wasm32-unknown-unknown --release
+//!
+//! Run: cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use zeroize::Zeroizing;
+
+use formix::adapter::external::ao::signer;
+use formix::adapter::external::ao::wallet::ArweaveJWK;
+use formix::adapter::external::ao::{AOClient, AOConfig, AOExecuteMsg, HyperBEAMClient};
+use formix::usecase::core::contract_storage::ContractStorageImpl;
+use formix::usecase::core::crypto::{CryptoService, CryptoServiceImpl as CoreCryptoServiceImpl};
+use formix::usecase::core::storage::ArweaveStorageServiceImpl;
+use formix::usecase::service::{
+    CryptoServiceImpl as ServiceCryptoServiceImpl,
+    StorageServiceImpl as ServiceStorageServiceImpl,
+};
+use formix::usecase::workflow::{
+    SecretRecoveryWorkflowServiceImpl, SecretSharingWorkflowService,
+    SecretSharingWorkflowServiceImpl, SecretRecoveryWorkflowService,
+};
+use formix::usecase::{SecretRecoveryRequest, SecretSharingRequest};
+
+#[tokio::test]
+#[ignore]
+async fn test_hyperbeam_e2e_share_and_recover() {
+    eprintln!("placeholder — will be implemented in subsequent tasks");
+}
+```
+
+**Import notes (review fix):**
+- `AOConfig` and `AOExecuteMsg` are re-exported from `formix::adapter::external::ao` — the sub-modules `config` and `message` are private. Use the re-export path.
+- `AOClient` trait must be in scope for `hb_client.execute()` calls.
+- `CryptoService` trait must be in scope for `core_crypto.generate_keypair()`.
+- `SecretSharingWorkflowService` and `SecretRecoveryWorkflowService` traits must be in scope for `execute_secret_sharing()` / `execute_secret_recovery()` calls.
+
+- [ ] **Step 2: Verify compilation with the hyperbeam feature**
+
+Run: `cargo check -p formix --features hyperbeam --tests 2>&1 | tail -5`
+Expected: SUCCESS (compiles with placeholder test)
+
+- [ ] **Step 3: Verify the test is listed but skipped in normal runs**
+
+Run: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e 2>&1 | tail -10`
+Expected: `test ... test_hyperbeam_e2e_share_and_recover ... ignored` (0 passed, 0 failed, 1 ignored)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/tests/integration/test_hyperbeam_e2e.rs
+git commit -m "test: add hyperbeam E2E test skeleton with imports"
+```
+
+---
+
+## Chunk 2: Helper Functions
+
+### Task 3: Implement wallet loading with skip logic
+
+**Files:**
+- Modify: `client/tests/integration/test_hyperbeam_e2e.rs`
+
+- [ ] **Step 1: Add the `load_wallet` helper function**
+
+Add above the test function:
+
+```rust
+/// Load ArweaveJWK from WALLET_PATH env var.
+/// Returns None (skip) if env var is unset or file is missing.
+fn load_wallet() -> Option<ArweaveJWK> {
+    let path = match std::env::var("WALLET_PATH") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("SKIP: WALLET_PATH not set — set it to an Arweave JWK file path");
+            return None;
+        }
+    };
+    match ArweaveJWK::from_file(&path) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            eprintln!("SKIP: failed to load wallet from {path}: {e}");
+            None
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the `check_hyperbeam_reachable` async helper**
+
+```rust
+/// Check if HyperBEAM node is reachable. Returns false (skip) if not.
+async fn check_hyperbeam_reachable(base_url: &str) -> bool {
+    let url = format!("{}/~meta@1.0/info", base_url);
+    match reqwest::get(&url).await {
+        Ok(resp) if resp.status().is_success() => true,
+        Ok(resp) => {
+            eprintln!("SKIP: HyperBEAM returned HTTP {}", resp.status());
+            false
+        }
+        Err(e) => {
+            eprintln!("SKIP: HyperBEAM unreachable at {base_url}: {e}");
+            false
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Update the test to use the skip helpers**
+
+Replace the placeholder test body:
+
+```rust
+#[tokio::test]
+#[ignore]
+async fn test_hyperbeam_e2e_share_and_recover() {
+    // ── Prerequisites ──
+    let wallet = match load_wallet() {
+        Some(w) => w,
+        None => return,
+    };
+
+    let config = AOConfig::new(
+        "http://localhost:10000",
+        "http://localhost:10000",
+        "http://localhost:10000",
+        60_000,
+    )
+    .expect("AOConfig");
+
+    if !check_hyperbeam_reachable(config.mu_url()).await {
+        return;
+    }
+
+    eprintln!("prerequisites OK — wallet loaded, HyperBEAM reachable");
+
+    // TODO: cache WASM, spawn process, run share/recover
+    eprintln!("placeholder — remaining steps not yet implemented");
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p formix --features hyperbeam --tests 2>&1 | tail -5`
+Expected: SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/tests/integration/test_hyperbeam_e2e.rs
+git commit -m "test: add wallet loading and HyperBEAM reachability helpers"
+```
+
+---
+
+### Task 4: Implement WASM cache helper
+
+**Files:**
+- Modify: `client/tests/integration/test_hyperbeam_e2e.rs`
+
+- [ ] **Step 1: Add the `locate_wasm_binary` helper**
+
+```rust
+/// Locate the WASM binary. Checks WASM_PATH env var, then the default build output.
+fn locate_wasm_binary() -> Option<Vec<u8>> {
+    let path = std::env::var("WASM_PATH").unwrap_or_else(|_| {
+        "ao/contracts/target/wasm32-unknown-unknown/release/formix_contract.wasm".to_string()
+    });
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            eprintln!("WASM binary loaded: {} ({} bytes)", path, bytes.len());
+            Some(bytes)
+        }
+        Err(e) => {
+            eprintln!(
+                "SKIP: WASM binary not found at {path}: {e}\n\
+                 Build with: cargo build -p formix-ao-contract --target wasm32-unknown-unknown --release"
+            );
+            None
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the `cache_wasm` async helper**
+
+This caches the WASM binary on HyperBEAM via `POST /~cache@1.0/write` with RFC-9421 signing:
+
+```rust
+/// Cache WASM binary on HyperBEAM. Returns the cache-id (SHA2-256 hash).
+async fn cache_wasm(
+    http: &reqwest::Client,
+    base_url: &str,
+    wasm_bytes: &[u8],
+    rsa_key: &rsa::RsaPrivateKey,
+    sig_name: &str,
+) -> Result<String, String> {
+    let url = format!("{}/~cache@1.0/write", base_url);
+
+    let signed = signer::sign_request(rsa_key, wasm_bytes, sig_name)
+        .map_err(|e| format!("signing WASM cache request: {e}"))?;
+
+    let resp = http
+        .post(&url)
+        .header("content-type", "application/wasm")
+        .header("content-digest", &signed.content_digest_header)
+        .header("signature", &signed.signature_header)
+        .header("signature-input", &signed.signature_input_header)
+        .body(wasm_bytes.to_vec())
+        .send()
+        .await
+        .map_err(|e| format!("cache POST: {e}"))?;
+
+    let status = resp.status();
+    let body = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("cache write failed (HTTP {status}): {body}"));
+    }
+
+    // Parse response — look for cache-id in JSON "path" field or "id" field
+    let v: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("parse cache response: {e}"))?;
+    let cache_id = v
+        .get("path")
+        .or_else(|| v.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("no path/id in cache response: {body}"))?;
+
+    eprintln!("WASM cached: {cache_id}");
+    Ok(cache_id.to_string())
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p formix --features hyperbeam --tests 2>&1 | tail -5`
+Expected: SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/tests/integration/test_hyperbeam_e2e.rs
+git commit -m "test: add WASM binary locator and cache helper"
+```
+
+---
+
+### Task 5: Implement process spawn helper
+
+**Files:**
+- Modify: `client/tests/integration/test_hyperbeam_e2e.rs`
+
+- [ ] **Step 1: Add the `spawn_process` async helper**
+
+This spawns a FORMIX contract process on HyperBEAM via `POST /schedule`:
+
+```rust
+/// Spawn a new FORMIX contract process on HyperBEAM.
+/// Returns the process ID (derived from signed process-definition hash).
+async fn spawn_process(
+    http: &reqwest::Client,
+    base_url: &str,
+    cache_id: &str,
+    scheduler_location: &str,
+    rsa_key: &rsa::RsaPrivateKey,
+    sig_name: &str,
+) -> Result<String, String> {
+    let test_seed = uuid::Uuid::new_v4().to_string();
+
+    let header_fields: BTreeMap<String, String> = BTreeMap::from([
+        ("device".to_string(), "process@1.0".to_string()),
+        ("type".to_string(), "Process".to_string()),
+        ("scheduler-device".to_string(), "scheduler@1.0".to_string()),
+        ("scheduler-location".to_string(), scheduler_location.to_string()),
+        ("execution-device".to_string(), "stack@1.0".to_string()),
+        (
+            "device-stack".to_string(),
+            "WASI@1.0,JSON-Iface@1.0,WASM-64@1.0,Multipass@1.0".to_string(),
+        ),
+        ("image".to_string(), cache_id.to_string()),
+        ("input-prefix".to_string(), "process".to_string()),
+        ("output-prefix".to_string(), "wasm".to_string()),
+        ("passes".to_string(), "2".to_string()),
+        ("stack-keys".to_string(), "init,compute".to_string()),
+        ("test-random-seed".to_string(), test_seed),
+    ]);
+
+    let body = b"";
+    let signed = signer::sign_message(rsa_key, &header_fields, body, sig_name)
+        .map_err(|e| format!("signing process spawn: {e}"))?;
+
+    let url = format!("{}/schedule", base_url);
+    let mut req = http.post(&url);
+    for (name, value) in &header_fields {
+        req = req.header(name.as_str(), value.as_str());
+    }
+    if !signed.content_digest_header.is_empty() {
+        req = req.header("content-digest", &signed.content_digest_header);
+    }
+    let resp = req
+        .header("signature", &signed.signature_header)
+        .header("signature-input", &signed.signature_input_header)
+        .body(body.to_vec())
+        .send()
+        .await
+        .map_err(|e| format!("spawn POST: {e}"))?;
+
+    let status = resp.status();
+    let resp_headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body_text = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("spawn failed (HTTP {status}): {body_text}"));
+    }
+
+    // Extract process ID from response headers or body
+    let process_id = resp_headers
+        .iter()
+        .find(|(k, _)| k == "process-id" || k == "process_id")
+        .map(|(_, v)| v.clone())
+        .or_else(|| {
+            serde_json::from_str::<serde_json::Value>(&body_text)
+                .ok()
+                .and_then(|v| {
+                    v.get("process")
+                        .or_else(|| v.get("id"))
+                        .or_else(|| v.get("process-id"))
+                        .and_then(|p| p.as_str())
+                        .map(|s| s.to_string())
+                })
+        })
+        .ok_or_else(|| {
+            format!("could not extract process ID from spawn response: headers={resp_headers:?}, body={body_text}")
+        })?;
+
+    // Verify process exists (spec requirement)
+    let verify_url = format!("{}/{}/compute", base_url, process_id);
+    let verify_resp = http
+        .get(&verify_url)
+        .header("slot", "0")
+        .send()
+        .await
+        .map_err(|e| format!("verify process: {e}"))?;
+    if !verify_resp.status().is_success() {
+        return Err(format!(
+            "process {} not found after spawn (HTTP {})",
+            process_id,
+            verify_resp.status()
+        ));
+    }
+
+    eprintln!("process spawned and verified: {process_id}");
+    Ok(process_id)
+}
+```
+
+- [ ] **Step 2: Add uuid to dev-dependencies in Cargo.toml**
+
+Check if `uuid` is already in `client/Cargo.toml` dev-dependencies. If not, add it:
+
+```toml
+[dev-dependencies]
+uuid = { version = "1", features = ["v4"] }
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p formix --features hyperbeam --tests 2>&1 | tail -5`
+Expected: SUCCESS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/tests/integration/test_hyperbeam_e2e.rs client/Cargo.toml
+git commit -m "test: add process spawn helper with RFC-9421 signing"
+```
+
+---
+
+## Chunk 3: E2E Test Body
+
+### Task 6: Wire services and implement the full test
+
+**Files:**
+- Modify: `client/tests/integration/test_hyperbeam_e2e.rs`
+
+- [ ] **Step 1: Replace the placeholder test with the full implementation**
+
+Replace the entire `test_hyperbeam_e2e_share_and_recover` function:
+
+```rust
+#[tokio::test]
+#[ignore]
+async fn test_hyperbeam_e2e_share_and_recover() {
+    // ── Prerequisites ──
+    let wallet = match load_wallet() {
+        Some(w) => w,
+        None => return,
+    };
+
+    let config = AOConfig::new(
+        "http://localhost:10000",
+        "http://localhost:10000",
+        "http://localhost:10000",
+        60_000,
+    )
+    .expect("AOConfig");
+    let base_url = config.mu_url().to_string();
+
+    if !check_hyperbeam_reachable(&base_url).await {
+        return;
+    }
+
+    let wasm_bytes = match locate_wasm_binary() {
+        Some(b) => b,
+        None => return,
+    };
+
+    // ── Setup signing material ──
+    let rsa_key = wallet
+        .to_rsa_private_key()
+        .expect("RSA key from wallet");
+    let sig_name = wallet.sig_name().expect("sig_name from wallet");
+    let scheduler_location = wallet.address().expect("wallet address");
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .expect("HTTP client");
+
+    // ── Cache WASM ──
+    let cache_id = cache_wasm(&http, &base_url, &wasm_bytes, &rsa_key, &sig_name)
+        .await
+        .expect("WASM cache failed");
+
+    // ── Spawn process ──
+    let process_id = spawn_process(
+        &http,
+        &base_url,
+        &cache_id,
+        &scheduler_location,
+        &rsa_key,
+        &sig_name,
+    )
+    .await
+    .expect("process spawn failed");
+
+    // ── Build HyperBEAMClient and send Init ──
+    let hb_client = Arc::new(
+        HyperBEAMClient::new(config, wallet).expect("HyperBEAMClient"),
+    );
+
+    let init_resp = hb_client
+        .execute(&process_id, AOExecuteMsg::init("Owner"))
+        .await
+        .expect("Init message failed");
+    assert!(
+        init_resp.ok,
+        "Init returned error: {:?}",
+        init_resp.error
+    );
+    eprintln!("Init OK for process {process_id}");
+
+    // ── Wire workflow services (in-memory Arweave + real HyperBEAM) ──
+    let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
+    let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
+    let arweave = Arc::new(ArweaveStorageServiceImpl::default());
+    let contract = Arc::new(ContractStorageImpl::new_single_process(hb_client));
+    let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
+
+    let sharing = SecretSharingWorkflowServiceImpl::new(
+        Arc::clone(&service_crypto),
+        Arc::clone(&storage),
+    );
+    let recovery = SecretRecoveryWorkflowServiceImpl::new(service_crypto, storage);
+
+    // ── Generate keypairs ──
+    let (owner_sk, owner_pk) = core_crypto.generate_keypair().unwrap();
+    let (requester_sk, requester_pk) = core_crypto.generate_keypair().unwrap();
+
+    let original_secret = b"HyperBEAM E2E test secret (k=3, n=5)";
+    let secret_data: Vec<u8> = original_secret.to_vec();
+
+    // ── Phase 1: share ──
+    eprintln!("Phase 1: executing secret sharing (k=3, n=5)...");
+    let phase1 = sharing
+        .execute_secret_sharing(SecretSharingRequest {
+            secret: Zeroizing::new(secret_data.clone()),
+            owner_secret_key: owner_sk,
+            owner_public_key: owner_pk.clone(),
+            requester_public_key: requester_pk,
+            threshold: 3,
+            total_shares: 5,
+            owner_process_id: process_id.clone(),
+            metadata: None,
+        })
+        .await
+        .expect("Phase 1 (share) failed");
+
+    eprintln!(
+        "Phase 1 OK: secret_id={}, kfrag_count={}",
+        phase1.secret_id, phase1.kfrag_count
+    );
+    assert_eq!(phase1.kfrag_count, 5);
+    assert_eq!(phase1.share_tx_ids.len(), 5);
+
+    // ── Phase 3: recover ──
+    eprintln!("Phase 3: executing secret recovery...");
+    let phase3 = recovery
+        .execute_secret_recovery(SecretRecoveryRequest {
+            secret_id: phase1.secret_id,
+            requester_secret_key: requester_sk,
+            owner_public_key: owner_pk,
+            requester_process_id: process_id.clone(),
+        })
+        .await
+        .expect("Phase 3 (recover) failed");
+
+    // ── Assertions ──
+    assert_eq!(
+        phase3.recovered_secret, secret_data,
+        "recovered secret must match original"
+    );
+    eprintln!("E2E PASS: recovered secret matches original ({} bytes)", secret_data.len());
+}
+```
+
+- [ ] **Step 2: Verify all trait imports are present**
+
+Confirm the import block (from Task 2) includes these traits:
+- `AOClient` — for `hb_client.execute()`
+- `CryptoService` — for `core_crypto.generate_keypair()`
+- `SecretSharingWorkflowService` — for `sharing.execute_secret_sharing()`
+- `SecretRecoveryWorkflowService` — for `recovery.execute_secret_recovery()`
+
+These were already added in Task 2's corrected import block.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p formix --features hyperbeam --tests 2>&1 | tail -5`
+Expected: SUCCESS
+
+- [ ] **Step 4: Verify the test is listed**
+
+Run: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --list 2>&1`
+Expected: `test_hyperbeam_e2e_share_and_recover: test` listed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/tests/integration/test_hyperbeam_e2e.rs
+git commit -m "test: implement full HyperBEAM E2E share/recover test"
+```
+
+---
+
+## Chunk 4: Deploy Script + Config
+
+### Task 7: Create the deploy script
+
+**Files:**
+- Create: `ao/scripts/deploy-hyperbeam.sh`
+
+- [ ] **Step 1: Write the deploy script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# HyperBEAM E2E test runner
+# Prerequisites: running HyperBEAM node, WALLET_PATH, WASM target installed
+#
+# Usage: WALLET_PATH=/path/to/wallet.json ./ao/scripts/deploy-hyperbeam.sh
+
+HB_PORT="${HB_PORT:-10000}"
+HB_URL="http://localhost:${HB_PORT}"
+
+echo "=== HyperBEAM E2E Test Runner ==="
+
+# 1. Check wallet
+if [ -z "${WALLET_PATH:-}" ]; then
+    echo "ERROR: WALLET_PATH is not set"
+    echo "  export WALLET_PATH=/path/to/arweave-wallet.json"
+    exit 1
+fi
+if [ ! -f "$WALLET_PATH" ]; then
+    echo "ERROR: wallet file not found: $WALLET_PATH"
+    exit 1
+fi
+echo "[OK] Wallet: $WALLET_PATH"
+
+# 2. Check HyperBEAM health
+if ! curl -sf "${HB_URL}/~meta@1.0/info" > /dev/null 2>&1; then
+    echo "ERROR: HyperBEAM not reachable at ${HB_URL}"
+    echo "  Start it with: cd hyperbeam-sandbox && ./scripts/start.sh"
+    exit 1
+fi
+echo "[OK] HyperBEAM: ${HB_URL}"
+
+# 3. Build WASM
+echo "Building WASM contract..."
+cargo build -p formix-ao-contract --target wasm32-unknown-unknown --release
+WASM_PATH="ao/contracts/target/wasm32-unknown-unknown/release/formix_contract.wasm"
+if [ ! -f "$WASM_PATH" ]; then
+    echo "ERROR: WASM binary not found at $WASM_PATH"
+    exit 1
+fi
+echo "[OK] WASM: $WASM_PATH ($(wc -c < "$WASM_PATH") bytes)"
+
+# 4. Run E2E test
+echo "Running E2E test..."
+export WASM_PATH
+cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture
+echo "=== DONE ==="
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run: `chmod +x ao/scripts/deploy-hyperbeam.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ao/scripts/deploy-hyperbeam.sh
+git commit -m "ci: add HyperBEAM E2E deploy/test runner script"
+```
+
+---
+
+### Task 8: Update deploy.example.json
+
+**Files:**
+- Modify: `deploy.example.json`
+
+- [ ] **Step 1: Add the hyperbeam section**
+
+Update `deploy.example.json` to:
+
+```json
+{
+  "module_id": "YOUR_AO_MODULE_ID",
+  "process_id": "YOUR_AO_PROCESS_ID",
+  "gateways": {
+    "ao_mu": "https://mu.ao-testnet.xyz",
+    "ao_cu": "https://cu.ao-testnet.xyz",
+    "arweave": "https://arweave.net"
+  },
+  "hyperbeam": {
+    "url": "http://localhost:10000",
+    "module_id": "YOUR_CACHED_WASM_ID",
+    "process_id": "YOUR_HYPERBEAM_PROCESS_ID"
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy.example.json
+git commit -m "docs: add hyperbeam section to deploy.example.json"
+```
+
+---
+
+## Chunk 5: Final Verification
+
+### Task 9: Run lint and full verification
+
+**Files:** (no new files)
+
+- [ ] **Step 1: Format check**
+
+Run: `make fmt`
+Expected: no changes needed (or auto-fixed)
+
+- [ ] **Step 2: Lint check**
+
+Run: `make lint`
+Expected: 0 errors
+
+- [ ] **Step 3: Run existing tests to ensure no regression**
+
+Run: `make test`
+Expected: all existing tests pass, hyperbeam test is not run (it's `#[ignore]` and feature-gated)
+
+- [ ] **Step 4: Verify the hyperbeam test compiles with feature**
+
+Run: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --list 2>&1`
+Expected: `test_hyperbeam_e2e_share_and_recover: test` is listed
+
+- [ ] **Step 5: Commit any remaining changes**
+
+If lint/fmt made changes:
+```bash
+git add -A
+git commit -m "style: apply formatting fixes"
+```
+
+---
+
+## Implementation Notes
+
+### Key API References
+
+- **`HyperBEAMClient::new(config, wallet)`** — `client/src/adapter/external/ao/hyperbeam_client.rs:19`
+- **`AOConfig::new(mu, cu, gw, timeout)`** — `client/src/adapter/external/ao/config.rs:27`
+- **`ArweaveJWK::from_file(path)`** — `client/src/adapter/external/ao/wallet.rs:46`
+- **`signer::sign_request(key, body, sig_name)`** — `client/src/adapter/external/ao/signer.rs:18`
+- **`signer::sign_message(key, headers, body, sig_name)`** — `client/src/adapter/external/ao/signer.rs:58`
+- **`AOExecuteMsg::init(role)`** — `client/src/adapter/external/ao/message.rs:96`
+- **`setup_e2e_services()` pattern** — `client/tests/integration/workflow_roundtrip_test.rs:656-679`
+- **`SecretSharingRequest` struct** — `client/src/usecase/dto.rs:21-39`
+- **`SecretRecoveryRequest` struct** — `client/src/usecase/dto.rs:83-92`
+- **`ContractStorageImpl::new_single_process(ao_client)`** — `client/src/usecase/core/contract_storage.rs:88`
+
+### Service Wiring Pattern (from workflow_roundtrip_test.rs:666-679)
+
+```
+CoreCryptoServiceImpl
+    └→ ServiceCryptoServiceImpl
+ArweaveStorageServiceImpl (in-memory)  ──┐
+ContractStorageImpl<HyperBEAMClient>  ──┤
+                                         └→ ServiceStorageServiceImpl
+                                              ├→ SecretSharingWorkflowServiceImpl
+                                              └→ SecretRecoveryWorkflowServiceImpl
+```
+
+### Error Skip Strategy
+
+All external dependencies use `eprintln!` + `return` for clean skip:
+- `WALLET_PATH` not set → skip
+- Wallet file unreadable → skip
+- HyperBEAM unreachable → skip
+- WASM binary missing → skip
+- WASM cache failure → **fail** (actionable error)
+- Process spawn failure → **fail**
+- Init failure → **fail**
+- Phase 1/3 failure → **fail**

--- a/docs/superpowers/specs/2026-05-11-hyperbeam-e2e-integration-test-design.md
+++ b/docs/superpowers/specs/2026-05-11-hyperbeam-e2e-integration-test-design.md
@@ -1,0 +1,300 @@
+# HyperBEAM E2E Integration Test Design
+
+## Goal
+
+Verify the full FORMIX flow (share → recover) against a real local HyperBEAM
+node, using the HyperBEAMClient adapter (Phase B, issue #88) and the migrated
+contract ABI (Phase C, issue #89).
+
+## Context
+
+- Parent issue: #86
+- This issue: #90
+- Dependencies: #88 (closed), #89 (closed)
+- Branch: `feat/hyperbeam-e2e-share-recover`
+
+The existing E2E tests in `workflow_roundtrip_test.rs` verify the Phase 1 → 2 → 3
+flow using `MockAOClient`. This design adds a test that replaces MockAOClient
+with a real `HyperBEAMClient` talking to a local HyperBEAM node.
+
+## Scope
+
+- `ao/scripts/deploy-hyperbeam.sh` — WASM build + test runner wrapper
+- `client/tests/integration/test_hyperbeam_e2e.rs` — E2E integration test
+- `deploy.example.json` — updated template with HyperBEAM section
+- `client/tests/integration.rs` — module registration (conditional)
+
+Out of scope: `cargo run --example basic_usage` (deferred to Phase E, issue #91).
+
+## Approach: Two-Phase Testing
+
+### Phase 1 (this issue): Mock Arweave + Real HyperBEAM
+
+Arweave storage uses the existing in-memory `ArweaveStorageServiceImpl::default()`.
+Only AO contract operations go through the real HyperBEAM node. This isolates
+contract behavior verification from Arweave network concerns.
+
+### Phase 2 (future): Full Real Stack
+
+Add a second test variant that also persists data to real Arweave (arweave.net
+or ArLocal). Not part of this issue.
+
+## Architecture
+
+### Service Wiring Strategy
+
+The existing DI types have a type mismatch for this test scenario:
+
+- `DefaultActionsContainer` is hardcoded to `ContractStorageImpl<MockAOClient>`
+- `HyperBEAMActionsContainer` uses `ProductionArweaveStorageService<ArweaveClientImpl>`
+  (real Arweave), not in-memory
+
+This test needs a hybrid: in-memory Arweave + real HyperBEAM. Instead of adding
+yet another type alias to `di.rs`, the test wires workflow services manually
+following the same pattern as `setup_e2e_services()` in
+`workflow_roundtrip_test.rs`:
+
+```rust
+// Manual wiring — replaces MockAOClient with HyperBEAMClient
+let core_crypto = Arc::new(CoreCryptoServiceImpl::new());
+let service_crypto = Arc::new(ServiceCryptoServiceImpl::new(Arc::clone(&core_crypto)));
+let arweave = Arc::new(ArweaveStorageServiceImpl::default()); // in-memory
+let contract = Arc::new(ContractStorageImpl::new_single_process(hb_client));
+let storage = Arc::new(ServiceStorageServiceImpl::new(arweave, contract));
+
+let sharing = SecretSharingWorkflowServiceImpl::new(
+    Arc::clone(&service_crypto), Arc::clone(&storage));
+let recovery = SecretRecoveryWorkflowServiceImpl::new(
+    service_crypto, storage);
+```
+
+This tests the workflow services directly (Phase 1 → Phase 2 → Phase 3),
+which is the same layer verified by the existing `test_e2e_full_pipeline_*`
+tests. The Actions/Controller layers are already covered by `builder_api_test.rs`.
+
+### Feature Gate
+
+The test file requires `#[cfg(feature = "hyperbeam")]` because `HyperBEAMClient`
+and related modules (signer, wallet, TABM encoder) are gated behind this feature
+in the source code. On native targets, the underlying crate dependencies (`rsa`,
+`reqwest`) are unconditionally available, but the HyperBEAM-specific API surface
+is feature-gated. The module registration in `integration.rs` must be conditional
+and placed inside the existing `mod integration { ... }` block:
+
+```rust
+mod integration {
+    // ... existing mods ...
+    #[cfg(feature = "hyperbeam")]
+    mod test_hyperbeam_e2e;
+}
+```
+
+The deploy script and manual test execution must include `--features hyperbeam`:
+
+```bash
+cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored
+```
+
+### Deploy Script (`ao/scripts/deploy-hyperbeam.sh`)
+
+A thin shell wrapper that:
+
+1. Validates prerequisites (HyperBEAM reachable, wallet exists, WASM built)
+2. Builds the WASM contract: `cargo build -p formix-ao-contract --target wasm32-unknown-unknown --release`
+3. Runs the E2E test: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture`
+
+The actual deploy logic (WASM cache + process spawn) runs inside the Rust test
+code, reusing the existing `HyperBEAMClient`, `signer.rs`, and `wallet.rs`
+implementations. This avoids reimplementing RFC-9421 signing in shell.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1. Check HyperBEAM health: curl -sf http://localhost:${HB_PORT:-10000}/~meta@1.0/info
+# 2. Check WALLET_PATH is set and file exists
+# 3. Build WASM: cargo build -p formix-ao-contract --target wasm32-unknown-unknown --release
+# 4. Run E2E: cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WALLET_PATH` | (required) | Path to Arweave JWK wallet file |
+| `WASM_PATH` | auto-detect from build output | Path to compiled WASM binary |
+
+Note: `AOConfig::default()` already points to `http://localhost:10000`.
+Override with `AO_MU_URL` / `AO_CU_URL` / `AO_GATEWAY_URL` if needed.
+No separate `HB_URL` variable — reuse the existing `AOConfig::from_env()`.
+
+### E2E Test (`client/tests/integration/test_hyperbeam_e2e.rs`)
+
+#### Test Setup
+
+```
+1. Load ArweaveJWK from WALLET_PATH env var
+   (skip test if not set)
+     ↓
+2. Build HyperBEAMClient with AOConfig::from_env() + wallet
+   (skip test if HyperBEAM unreachable)
+     ↓
+3. Cache WASM binary: POST /~cache@1.0/write
+   Body = raw WASM bytes, RFC-9421 signed
+   Response: cache-id (SHA2-256 hash of binary)
+     ↓
+4. Spawn process: POST /schedule
+   Signed process-definition with tags:
+     device: "process@1.0"
+     type: "Process"
+     scheduler-device: "scheduler@1.0"
+     scheduler-location: <wallet-address>
+     execution-device: "stack@1.0"
+     device-stack: ["WASI@1.0", "JSON-Iface@1.0", "WASM-64@1.0", "Multipass@1.0"]
+     image: <cache-id>
+     input-prefix: "process"
+     output-prefix: "wasm"
+     passes: 2
+     stack-keys: ["init", "compute"]
+     test-random-seed: <uuid>  (unique per test run)
+   Process ID = hash of signed process-def message (client-derived)
+     ↓
+5. Send Init message: HyperBEAMClient.execute(process_id, AOExecuteMsg::init("Owner"))
+   Role = "Owner" for single-process setup (Owner == Holder).
+   Verify successful response before proceeding
+     ↓
+6. Wire workflow services manually:
+   arweave = ArweaveStorageServiceImpl::default()  (in-memory)
+   contract = ContractStorageImpl::new_single_process(hb_client)
+   sharing_service + recovery_service wired with these
+```
+
+#### Test Flow
+
+Threshold parameters: k=3, n=5 (matches existing test conventions).
+
+```
+[share] Phase 1
+  generate_keypair() × 2 (owner, requester)
+  sharing_service.execute_secret_sharing(SecretSharingRequest {
+      secret: original_bytes,
+      threshold: 3,
+      total_shares: 5,
+      owner_secret_key, owner_public_key,
+      requester_public_key,
+      owner_process_id: <spawned process_id>,
+  })
+  → Phase1Result { secret_id, kfrag_count: 5, ... }
+    ↓
+[recover] Phase 3
+  recovery_service.execute_secret_recovery(SecretRecoveryRequest {
+      secret_id: phase1.secret_id,
+      requester_secret_key,
+      owner_public_key,
+      requester_process_id: <spawned process_id>,
+  })
+  → Phase3Result { recovered_secret }
+    ↓
+[assert]
+  assert_eq!(recovered_secret, original_bytes)
+```
+
+#### Test Attributes
+
+- `#[tokio::test]` — async test runtime
+- `#[ignore]` — skipped by default; run manually when HyperBEAM is available
+- `#[cfg(feature = "hyperbeam")]` — requires hyperbeam feature
+- Execution: `cargo test -p formix --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture`
+
+#### WASM Cache Helper
+
+Caches the WASM binary on the local HyperBEAM node:
+
+1. Read WASM binary from `WASM_PATH` env var or auto-detect from
+   `ao/contracts/target/wasm32-unknown-unknown/release/formix_contract.wasm`
+2. `POST /~cache@1.0/write` with raw WASM bytes as body
+   - RFC-9421 signed with the test wallet
+   - Cache writers authorization: default HyperBEAM config auto-populates
+     `cache_writers` with the node wallet address. If the test wallet differs
+     from the node wallet, the node's config must include the test wallet address.
+3. Parse response for `path` field = cache-id (deterministic SHA2-256 hash)
+4. Return cache-id for use in spawn
+
+#### Process Spawn Helper
+
+Spawns a new FORMIX contract process:
+
+1. Build process-definition message with all required tags (see Test Setup step 4)
+2. Sign with RFC-9421 using the test wallet
+3. `POST /schedule` — body is the signed process-definition
+4. Compute process ID client-side: hash of the signed process-definition message
+   (deterministic — the node does not assign IDs server-side)
+5. Verify process exists: `GET /<ProcID>/compute` with slot=0 header
+6. Return process_id
+
+Note: `test-random-seed` field with a UUID ensures unique process IDs across
+test runs even with the same WASM image and wallet.
+
+#### Timeout Configuration
+
+`AOConfig` default timeout is 30 seconds. WASM compilation and initial process
+setup on HyperBEAM may require more time. The test should construct `AOConfig`
+with a 60-second timeout via `AOConfig::new(url, url, url, 60_000)` and use a
+single `HyperBEAMClient` instance for both setup and test execution.
+
+### deploy.example.json Update
+
+Add a `hyperbeam` section to the existing template:
+
+```json
+{
+  "module_id": "YOUR_AO_MODULE_ID",
+  "process_id": "YOUR_AO_PROCESS_ID",
+  "gateways": {
+    "ao_mu": "https://mu.ao-testnet.xyz",
+    "ao_cu": "https://cu.ao-testnet.xyz",
+    "arweave": "https://arweave.net"
+  },
+  "hyperbeam": {
+    "url": "http://localhost:10000",
+    "module_id": "YOUR_CACHED_WASM_ID",
+    "process_id": "YOUR_HYPERBEAM_PROCESS_ID"
+  }
+}
+```
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `ao/scripts/deploy-hyperbeam.sh` | Create | Shell wrapper: prereq check + WASM build + test run |
+| `client/tests/integration/test_hyperbeam_e2e.rs` | Create | E2E test with WASM cache + spawn helpers |
+| `deploy.example.json` | Modify | Add `hyperbeam` section |
+| `client/tests/integration.rs` | Modify | Add `#[cfg(feature = "hyperbeam")] mod test_hyperbeam_e2e;` |
+
+## Error Handling
+
+- If `WALLET_PATH` is not set or file missing → skip test with clear message
+- If HyperBEAM node is unreachable → skip test with connection error message
+- If WASM binary not found → skip test with build instruction message
+- If WASM cache fails (e.g., auth issue) → fail with actionable error
+- If process spawn fails → fail with process-definition details
+- If Init message fails → fail with HyperBEAM error response
+- All skip conditions use `eprintln!` + `return` (not panic) for clean output
+
+## Security Considerations
+
+- Wallet JWK file is loaded via `WALLET_PATH` environment variable, never
+  committed to repository
+- Test wallet should be a dedicated test-only wallet with no mainnet funds
+- Error messages must not expose wallet key material
+- Cache writer authorization: the test wallet must be in the HyperBEAM node's
+  `cache_writers` list (default: node's own wallet address)
+
+## Done Criteria Mapping
+
+| Criterion | Verification |
+|-----------|-------------|
+| `share()` + `recover()` succeeds against local HyperBEAM | `test_hyperbeam_e2e_share_and_recover` passes |
+| Recovered secret matches original bytes | `assert_eq!(recovered_secret, original_bytes)` |
+| Test is reproducible from clean state | Each test run spawns a fresh process via `test-random-seed` |


### PR DESCRIPTION
# 概要

Issue #90: [Phase D] E2E Integration Test — share() + recover() on real HyperBEAM

ローカル HyperBEAM ノードに対する share → recover のフル E2E が **グリーン**
(復元バイト列 == 元秘密、クリーンステート再現確認済み)。実ノード検証で発見した
client/contract のバグ (#101, #102 ほか) もこの PR で修正する。

## 変更内容

### E2E テスト & ランナー
- `client/tests/integration/test_hyperbeam_e2e.rs` (新規): RPC で WASM image をキャッシュ →
  canonical JSON-Iface stack (typed `device-stack`/`stack-keys`/`passes` ヘッダー) で
  process spawn → `Init(Combined)` → Phase 1 share → Phase 3 recover → バイト一致 assert
- `ao/scripts/deploy-hyperbeam.sh` (新規): 前提チェック + WASM ビルド + **wasm-tools 正規化 (#101)**
  + image キャッシュ + テスト実行
- `ao/scripts/cache-wasm.escript` (新規): message 形式の image キャッシュ
  (HTTP `~cache@1.0` の raw binary 書き込みは `data/<hash>` に置かれ image 参照不可)

### client 修正 (E2E で発見)
- `HyperBEAMClient::query` は `/now` スタブだった → query を schedule し、
  `results/data/serialize~json@1.0` で contract の JSON レスポンスを取得 (**#102**)
- `execute()` を schedule-only 化: HyperBEAM は wasm-64 snapshot をリクエスト間で
  復元できない (sandbox M4 知見) ため、compute は recovery 時の 1 回のみ
- `retrieve_cfrags` を単一の batch `GetCFrags` クエリに変更 (同上の理由)。Mock も同 action 実装

### contract 修正
- `AOSResponse`: エラーも `ok: true` + `{"Error": ...}` 形状に
  (dev_json_iface は `ok: false` で replay 全体を abort する)
- Combined ロールで `SubmitKFrag`/`SubmitCapsule` をインライン配送
  (process outbox はこのフローでは push されない) — single-process で再暗号化が実際に走るように
- cFrag は raw rmp bytes で保存 (bincode ラッパーは client 復元を壊す)
- batch `GetCFrags` ハンドラー追加

## テスト方法

```bash
# HyperBEAM ノード起動 (hyperbeam-sandbox: make start)
WALLET_PATH=<node-operator-jwk> ./ao/scripts/deploy-hyperbeam.sh
```

前提: HyperBEAM が localhost:10000 で稼働 / WALLET_PATH はノードの operator key
(cache_writers 制約) / `wasm-tools` インストール済み

## 検証

- E2E: `E2E SUCCESS: recovered secret matches original` (ノード再起動後のクリーンステートでも再現)
- `cd client && make all` → exit 0 (288 unit / 66 integration / 15 doc)
- `cd ao/contracts && cargo fmt --check && cargo check/clippy (-D warnings) && cargo test` → green (10 tests)
- `docs/status.md` 更新済み

Closes #90
Closes #101
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)