### PR TITLE
fix: signer keyid must be base64url(n) for HyperBEAM signer derivation (closes #99)

### DIFF
--- a/client/src/adapter/external/ao/signer.rs
+++ b/client/src/adapter/external/ao/signer.rs
@@ -1,4 +1,4 @@
-use base64::engine::general_purpose::STANDARD;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use rsa::pss::BlindedSigningKey;
 use rsa::signature::{RandomizedSigner, SignatureEncoding};
@@ -36,7 +36,9 @@ pub fn sign_request(
 
     let created = unix_timestamp()?;
 
-    let keyid = STANDARD.encode(key.n().to_bytes_be());
+    // HyperBEAM derives the signer address from keyid (sha256 of the decoded
+    // modulus), so this must be base64url-no-pad — identical to the JWK `n`.
+    let keyid = URL_SAFE_NO_PAD.encode(key.n().to_bytes_be());
     let covered_components = "\"content-digest\"";
 
     let signature_input = format!(
@@ -78,7 +80,9 @@ pub fn sign_message(
 
     let created = unix_timestamp()?;
 
-    let keyid = STANDARD.encode(key.n().to_bytes_be());
+    // HyperBEAM derives the signer address from keyid (sha256 of the decoded
+    // modulus), so this must be base64url-no-pad — identical to the JWK `n`.
+    let keyid = URL_SAFE_NO_PAD.encode(key.n().to_bytes_be());
 
     let mut components: Vec<(String, String)> = headers
         .iter()

--- a/client/tests/unit/adapter/external/ao/signer.rs
+++ b/client/tests/unit/adapter/external/ao/signer.rs
@@ -1,6 +1,7 @@
-use base64::engine::general_purpose::STANDARD;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use rand::rngs::OsRng;
+use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -43,6 +44,40 @@ fn test_sign_request_signature_input_format() {
     assert!(signed.signature_input_header.contains("created="));
     assert!(signed.signature_input_header.contains("keyid=\""));
     assert!(signed.signature_input_header.contains("\"content-digest\""));
+}
+
+// HyperBEAM derives the signer address from keyid, so it must be the
+// base64url-no-pad modulus — identical to the JWK `n` field (issue #99).
+#[test]
+fn test_sign_request_keyid_is_base64url_modulus() {
+    let key = test_rsa_key();
+    let signed = signer::sign_request(&key, b"data", "my-sig").unwrap();
+
+    let expected = URL_SAFE_NO_PAD.encode(key.n().to_bytes_be());
+    assert!(
+        signed
+            .signature_input_header
+            .contains(&format!("keyid=\"{expected}\"")),
+        "keyid must be base64url(n): {}",
+        signed.signature_input_header
+    );
+}
+
+#[test]
+fn test_sign_message_keyid_is_base64url_modulus() {
+    let key = test_rsa_key();
+    let mut headers = BTreeMap::new();
+    headers.insert("action".to_string(), "Ping".to_string());
+    let signed = signer::sign_message(&key, &headers, b"body", "my-sig").unwrap();
+
+    let expected = URL_SAFE_NO_PAD.encode(key.n().to_bytes_be());
+    assert!(
+        signed
+            .signature_input_header
+            .contains(&format!("keyid=\"{expected}\"")),
+        "keyid must be base64url(n): {}",
+        signed.signature_input_header
+    );
 }
 
 #[test]


### PR DESCRIPTION
# 概要

HyperBEAM は HTTP signature の keyid から署名者アドレスを導出する (sha256(decode(keyid)))。
FORMIX の signer は keyid を base64 STANDARD でエンコードしていたため、アドレスが一致せず
`~cache@1.0/write` の `is_trusted_writer` で HTTP 403 になっていた (E2E #90 のブロッカー)。

## 変更内容

- `signer.rs`: `sign_request` / `sign_message` の keyid を `URL_SAFE_NO_PAD.encode(n)` に変更
  (JWK の `n` フィールド、および hyperbeam-sandbox の実証済み `hb-client` と同一)
- unit test 2 件追加 (keyid が base64url(n) であることを検証、TDD で先に fail を確認)

## 検証

- `cd client && make all` → exit 0 (288 unit / 65 integration / 15 doc)
- 新規テスト: `test_sign_request_keyid_is_base64url_modulus`, `test_sign_message_keyid_is_base64url_modulus`

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)