### PR TITLE
feat: public endpoint E2E + ao/deploy.json record (closes #104)

### DIFF
--- a/ao/deploy.json
+++ b/ao/deploy.json
@@ -1,0 +1,8 @@
+{
+  "hyperbeam": {
+    "url": "https://beliefs-apartments-tackle-forgotten.trycloudflare.com",
+    "image_id": "AaxzQClpMJdaQEl9pG-1yIaZnh4oBOLqkgs04BzTF4o",
+    "process_id": "lElBQEIMiAw57vRV3fvirpBlcbPO1amXLwa_a1pah-o",
+    "deployed_at": "2026-06-12T00:25:31Z"
+  }
+}

--- a/ao/scripts/deploy-hyperbeam.sh
+++ b/ao/scripts/deploy-hyperbeam.sh
@@ -4,10 +4,15 @@ set -euo pipefail
 # HyperBEAM E2E test runner
 # Prerequisites: running HyperBEAM node, WALLET_PATH, WASM target installed
 #
-# Usage: WALLET_PATH=/path/to/wallet.json ./ao/scripts/deploy-hyperbeam.sh
+# Usage:
+#   WALLET_PATH=/path/to/wallet.json ./ao/scripts/deploy-hyperbeam.sh
+#   # Against a public endpoint (image caching still happens over local RPC):
+#   WALLET_PATH=... HYPERBEAM_URL=https://node.example.com ./ao/scripts/deploy-hyperbeam.sh
 
 HB_PORT="${HB_PORT:-10000}"
 HB_URL="http://localhost:${HB_PORT}"
+# Endpoint the E2E test talks to; defaults to the local node.
+HYPERBEAM_URL="${HYPERBEAM_URL:-${HB_URL}}"
 
 echo "=== HyperBEAM E2E Test Runner ==="
 
@@ -29,7 +34,14 @@ if ! curl -sf "${HB_URL}/~meta@1.0/info" > /dev/null 2>&1; then
     echo "  Start it with: cd hyperbeam-sandbox && ./scripts/start.sh"
     exit 1
 fi
-echo "[OK] HyperBEAM: ${HB_URL}"
+echo "[OK] HyperBEAM (local): ${HB_URL}"
+if [ "$HYPERBEAM_URL" != "$HB_URL" ]; then
+    if ! curl -sf "${HYPERBEAM_URL}/~meta@1.0/info" > /dev/null 2>&1; then
+        echo "ERROR: public endpoint not reachable at ${HYPERBEAM_URL}"
+        exit 1
+    fi
+    echo "[OK] HyperBEAM (public endpoint): ${HYPERBEAM_URL}"
+fi
 
 # Repo has no root cargo workspace — client/ and ao/contracts/ are standalone crates,
 # so each cargo invocation needs an explicit manifest path.
@@ -74,7 +86,27 @@ echo "[OK] Image ID: $WASM_IMAGE_ID"
 
 # 5. Run E2E test
 echo "Running E2E test..."
-export WASM_IMAGE_ID
+export WASM_IMAGE_ID HYPERBEAM_URL
+TEST_LOG="$(mktemp -t formix-e2e).log"
 cargo test --manifest-path "${REPO_ROOT}/client/Cargo.toml" \
-    --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture
+    --features hyperbeam test_hyperbeam_e2e -- --ignored --nocapture \
+    2>&1 | tee "$TEST_LOG"
+
+# 6. Record the deployment so the run is reproducible (DoD: ao/deploy.json)
+PROCESS_ID="$(grep -oE 'Process spawned: [A-Za-z0-9_-]+' "$TEST_LOG" | tail -1 | awk '{print $3}')"
+if [ -n "$PROCESS_ID" ]; then
+    DEPLOYED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "${REPO_ROOT}/ao/deploy.json" <<JSON
+{
+  "hyperbeam": {
+    "url": "${HYPERBEAM_URL}",
+    "image_id": "${WASM_IMAGE_ID}",
+    "process_id": "${PROCESS_ID}",
+    "deployed_at": "${DEPLOYED_AT}"
+  }
+}
+JSON
+    echo "[OK] Recorded deployment to ao/deploy.json (process_id: ${PROCESS_ID})"
+fi
+rm -f "$TEST_LOG"
 echo "=== DONE ==="

--- a/deploy.example.json
+++ b/deploy.example.json
@@ -7,8 +7,9 @@
     "arweave": "https://arweave.net"
   },
   "hyperbeam": {
-    "url": "http://localhost:10000",
-    "module_id": "YOUR_CACHED_WASM_ID",
-    "process_id": "YOUR_HYPERBEAM_PROCESS_ID"
+    "url": "https://YOUR_PUBLIC_OR_LOCAL_HYPERBEAM_URL",
+    "image_id": "YOUR_CACHED_WASM_IMAGE_ID",
+    "process_id": "YOUR_HYPERBEAM_PROCESS_ID",
+    "deployed_at": "1970-01-01T00:00:00Z"
   }
 }


### PR DESCRIPTION
# 概要

PoC MVP (#86) Phase 2-1: 公開エンドポイント経由の E2E と デプロイ記録 (DoD #4/#5)。

## 変更内容

- `deploy-hyperbeam.sh`: `HYPERBEAM_URL` 指定で E2E を公開エンドポイントに向ける
  (公開 URL の疎通チェック付き。image キャッシュは従来どおりノード横の RPC)
- E2E グリーン後に `ao/deploy.json` へ url / image_id / process_id / deployed_at を記録
- `ao/deploy.json`: cloudflared quick tunnel 経由の実デプロイ記録
  (`E2E SUCCESS: recovered secret matches original`, process_id: lElBQEIMiAw57vRV3fvirpBlcbPO1amXLwa_a1pah-o)
- `deploy.example.json` の hyperbeam セクションを新フォーマットに更新

## 公開ノード選定の経緯

forward.computer 系 (mainnet 現行) は署名プロトコル刷新 (#103) により固定版の署名を受理しないため、
PoC では固定版ノード + 公開トンネルを採用。Arweave anchoring は #105、mainnet 対応は #103 で追跡。

## 検証

```
[OK] HyperBEAM (public endpoint): https://beliefs-apartments-tackle-forgotten.trycloudflare.com
E2E SUCCESS: recovered secret matches original
[OK] Recorded deployment to ao/deploy.json (process_id: lElBQEIMiAw57vRV3fvirpBlcbPO1amXLwa_a1pah-o)
```

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)