### PR TITLE
feat: anchor L1 fallback + actual Arweave anchoring of MVP deployment (closes #108)

### DIFF
--- a/ao/deploy.json
+++ b/ao/deploy.json
@@ -1,8 +1,12 @@
 {
   "hyperbeam": {
-    "url": "https://beliefs-apartments-tackle-forgotten.trycloudflare.com",
+    "url": "https://260e5186856076.lhr.life",
     "image_id": "AaxzQClpMJdaQEl9pG-1yIaZnh4oBOLqkgs04BzTF4o",
-    "process_id": "lElBQEIMiAw57vRV3fvirpBlcbPO1amXLwa_a1pah-o",
-    "deployed_at": "2026-06-12T00:25:31Z"
+    "process_id": "lQjYYokaQimZqwYMWc8srp6f0oghPs5lTIB64oNfCLw",
+    "deployed_at": "2026-07-05T04:46:12Z",
+    "anchor": {
+      "schedule-export": "MKN8VQ2UZkgZ4YuGQGmKsm-qI4x7GDkC54_v559jeeU",
+      "wasm-module": "5nOd_VPMRM_I-jIwPDjd3vwdIxGY9HVFyfpE5AUhMFI"
+    }
   }
 }

--- a/ao/scripts/anchor-arweave.mjs
+++ b/ao/scripts/anchor-arweave.mjs
@@ -122,20 +122,13 @@ async function main() {
   }
   const jwk = JSON.parse(await readFile(walletPath, "utf8"));
 
-  const { TurboFactory } = await import("@ardrive/turbo-sdk");
-  const turbo = TurboFactory.authenticated({ privateKey: jwk });
-
-  const uploaded = [];
-  for (const item of items) {
-    console.log(`[anchor] uploading ${item.label} (${item.data.length} bytes)...`);
-    const result = await turbo.uploadFile({
-      fileStreamFactory: () => Readable.from(item.data),
-      fileSizeFactory: () => item.data.length,
-      dataItemOpts: { tags: item.tags },
-    });
-    console.log(`[anchor]   -> ${item.label}: ${result.id}`);
-    uploaded.push({ label: item.label, id: result.id });
-  }
+  // Upload method: `turbo` (bundled, needs Turbo credits) or `l1` (direct
+  // top-level Arweave transactions, paid in AR). `auto` (default) uses Turbo
+  // when the account has enough credits, otherwise falls back to L1 — L1 is
+  // also the stronger attribution (permanent on-chain txs, no bundler).
+  const method = (process.env.ANCHOR_METHOD ?? "auto").toLowerCase();
+  const uploaded =
+    (await tryTurbo(jwk, items, method)) ?? (await uploadL1(jwk, items, method));
 
   // 2. Record the anchor IDs next to the deployment record.
   const deployJson = await loadDeployJson();
@@ -154,6 +147,83 @@ async function main() {
     const found = await pollGateway(id);
     console.log(`[anchor] gateway ${found ? "indexed" : "NOT YET indexed"}: ${label} (${id})`);
   }
+}
+
+// Upload via Turbo if the account has enough credits (or method forces it).
+// Returns the uploaded list, or null to signal "fall back to L1".
+async function tryTurbo(jwk, items, method) {
+  if (method === "l1") return null;
+
+  const { TurboFactory } = await import("@ardrive/turbo-sdk");
+  const turbo = TurboFactory.authenticated({ privateKey: jwk });
+  const totalBytes = items.reduce((n, it) => n + it.data.length, 0);
+
+  const [{ winc: costWinc }] = await turbo.getUploadCosts({ bytes: [totalBytes] });
+  const { winc: balanceWinc } = await turbo.getBalance();
+  const enough = BigInt(balanceWinc) >= BigInt(costWinc);
+  console.log(`[anchor] Turbo balance ${balanceWinc} winc, need ${costWinc} winc`);
+
+  if (!enough) {
+    if (method === "turbo") {
+      throw new Error(
+        `insufficient Turbo credits (${balanceWinc} < ${costWinc}); top up or use ANCHOR_METHOD=l1`,
+      );
+    }
+    console.log("[anchor] insufficient Turbo credits — falling back to direct L1 upload");
+    return null;
+  }
+
+  const uploaded = [];
+  for (const item of items) {
+    console.log(`[anchor] uploading ${item.label} via Turbo (${item.data.length} bytes)...`);
+    const result = await turbo.uploadFile({
+      fileStreamFactory: () => Readable.from(item.data),
+      fileSizeFactory: () => item.data.length,
+      dataItemOpts: { tags: item.tags },
+    });
+    console.log(`[anchor]   -> ${item.label}: ${result.id}`);
+    uploaded.push({ label: item.label, id: result.id });
+  }
+  return uploaded;
+}
+
+// Upload each item as a direct top-level Arweave transaction, paid in AR.
+async function uploadL1(jwk, items, method) {
+  const { default: Arweave } = await import("arweave");
+  const arweave = Arweave.init({ host: "arweave.net", port: 443, protocol: "https" });
+
+  const address = await arweave.wallets.jwkToAddress(jwk);
+  const balanceWinston = await arweave.wallets.getBalance(address);
+
+  let totalCost = 0n;
+  for (const item of items) {
+    totalCost += BigInt(await arweave.transactions.getPrice(item.data.length));
+  }
+  console.log(
+    `[anchor] L1 wallet ${address}: balance ${balanceWinston} winston, tx cost ~${totalCost} winston`,
+  );
+  if (BigInt(balanceWinston) < totalCost) {
+    throw new Error(
+      `insufficient AR for L1 upload (${balanceWinston} < ${totalCost} winston). Fund ${address}.`,
+    );
+  }
+
+  const uploaded = [];
+  for (const item of items) {
+    console.log(`[anchor] uploading ${item.label} via L1 (${item.data.length} bytes)...`);
+    const tx = await arweave.createTransaction({ data: item.data }, jwk);
+    for (const tag of item.tags) tx.addTag(tag.name, tag.value);
+    await arweave.transactions.sign(tx, jwk);
+    const uploader = await arweave.transactions.getUploader(tx);
+    while (!uploader.isComplete) {
+      await uploader.uploadChunk();
+      process.stdout.write(`\r[anchor]   ${item.label}: ${uploader.pctComplete}%   `);
+    }
+    process.stdout.write("\n");
+    console.log(`[anchor]   -> ${item.label}: ${tx.id}`);
+    uploaded.push({ label: item.label, id: tx.id });
+  }
+  return uploaded;
 }
 
 async function pollGateway(id, attempts = 10, intervalMs = 15_000) {

--- a/ao/scripts/package-lock.json
+++ b/ao/scripts/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "formix-ao-scripts",
       "dependencies": {
-        "@ardrive/turbo-sdk": "^1.20.0"
+        "@ardrive/turbo-sdk": "^1.20.0",
+        "arweave": "^1.15.7"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/ao/scripts/package.json
+++ b/ao/scripts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@ardrive/turbo-sdk": "^1.20.0"
+    "@ardrive/turbo-sdk": "^1.20.0",
+    "arweave": "^1.15.7"
   }
 }


### PR DESCRIPTION
# 概要

PoC MVP (#86) Phase 2-2 完了: 「ログとコードが Arweave にあり、固定版ビルドで誰でも再実行検証できる」状態を実現。

## 背景

#105 の anchor スクリプトは Turbo (bundled) 前提だったが、設置された運用ウォレットは
AR 残高のみで Turbo クレジット 0 だったため、>100KiB のアイテムがアップロードできなかった。
Turbo 不足時に **Arweave L1 直接 tx** (arweave-js, AR 支払い) にフォールバックする方式を追加。
L1 はむしろ帰属が最も強い (bundler を介さないトップレベル tx として恒久記録)。

## 変更内容

- `anchor-arweave.mjs`: `ANCHOR_METHOD=auto|turbo|l1` (default auto)。
  Turbo 残高 >= 費用なら Turbo、不足なら L1 に自動フォールバック
  (createTransaction → sign → chunk uploader)
- `arweave` (arweave-js) 依存追加

## 実 anchoring (ブロック 1952502 で確定)

| アイテム | tx ID |
|---|---|
| assignment ログ (scheduler 署名付き) | `MKN8VQ2UZkgZ4YuGQGmKsm-qI4x7GDkC54_v559jeeU` |
| WASM モジュール | `5nOd_VPMRM_I-jIwPDjd3vwdIxGY9HVFyfpE5AUhMFI` |

コスト ~0.00795 AR。`ao/deploy.json` に記録。gateway インデックス確認済み。

## 検証

```
[anchor] Turbo balance 0 winc, need 5401406517 winc
[anchor] insufficient Turbo credits — falling back to direct L1 upload
[anchor]   -> schedule-export: MKN8VQ2UZkgZ4YuGQGmKsm-qI4x7GDkC54_v559jeeU
[anchor]   -> wasm-module: 5nOd_VPMRM_I-jIwPDjd3vwdIxGY9HVFyfpE5AUhMFI
[anchor] gateway indexed: schedule-export / wasm-module
```
tx status: block_height 1952502, confirmations 1+

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)